### PR TITLE
兼容 Shadowsocks simple-obfs 订阅插件别名

### DIFF
--- a/internal/subscription/parser.go
+++ b/internal/subscription/parser.go
@@ -2229,10 +2229,13 @@ func parseNetchURI(uri string) (ParsedNode, bool) {
 			"method":      method,
 			"password":    password,
 		}
-		if plugin := strings.TrimSpace(getString(nodeMap, "Plugin")); plugin != "" {
+		plugin := strings.TrimSpace(getString(nodeMap, "Plugin"))
+		pluginOpts := strings.TrimSpace(getString(nodeMap, "PluginOption"))
+		plugin, pluginOpts = normalizeSSPlugin(plugin, pluginOpts)
+		if plugin != "" {
 			outbound["plugin"] = plugin
 		}
-		if pluginOpts := strings.TrimSpace(getString(nodeMap, "PluginOption")); pluginOpts != "" {
+		if pluginOpts != "" {
 			outbound["plugin_opts"] = pluginOpts
 		}
 		return buildParsedNode(outbound)
@@ -2613,6 +2616,7 @@ func parseSSDURI(uri string) ([]ParsedNode, bool) {
 			getString(server, "plugin_opts"),
 			defaultPluginOpts,
 		))
+		plugin, pluginOpts = normalizeSSPlugin(plugin, pluginOpts)
 		if plugin != "" {
 			outbound["plugin"] = plugin
 		}
@@ -3528,17 +3532,18 @@ func parseSSPluginFromQuery(rawQuery string) (plugin string, pluginOpts string) 
 					query.Get("plugin_opts"),
 				))
 				if pluginOpts == "" && rawOpts != "" {
-					if optsPlugin, optsValue := splitSSPluginSpec(rawOpts); optsPlugin != "" && optsValue != "" && strings.EqualFold(optsPlugin, plugin) {
+					if optsPlugin, optsValue := splitSSPluginSpec(rawOpts); optsPlugin != "" && optsValue != "" && canonicalSSPluginName(optsPlugin) == canonicalSSPluginName(plugin) {
 						pluginOpts = optsValue
 					} else {
 						pluginOpts = rawOpts
 					}
 				}
-				return plugin, pluginOpts
+				return normalizeSSPlugin(plugin, pluginOpts)
 			}
 		}
 		if spec := strings.TrimSpace(firstNonEmpty(query.Get("plugin-opts"), query.Get("plugin_opts"))); spec != "" {
-			return splitSSPluginSpec(spec)
+			plugin, pluginOpts = splitSSPluginSpec(spec)
+			return normalizeSSPlugin(plugin, pluginOpts)
 		}
 	}
 
@@ -3546,7 +3551,8 @@ func parseSSPluginFromQuery(rawQuery string) (plugin string, pluginOpts string) 
 	if spec == "" {
 		return "", ""
 	}
-	return splitSSPluginSpec(spec)
+	plugin, pluginOpts = splitSSPluginSpec(spec)
+	return normalizeSSPlugin(plugin, pluginOpts)
 }
 
 func extractSSPluginSpecFromRawQuery(rawQuery string) string {
@@ -3577,7 +3583,7 @@ func splitSSPluginSpec(spec string) (plugin string, pluginOpts string) {
 	if spec == "" {
 		return "", ""
 	}
-	parts := strings.Split(spec, ";")
+	parts := splitUnescaped(spec, ';')
 	plugin = strings.TrimSpace(parts[0])
 	if plugin == "" {
 		return "", ""
@@ -3593,6 +3599,106 @@ func splitSSPluginSpec(spec string) (plugin string, pluginOpts string) {
 		}
 	}
 	return plugin, strings.Join(rest, ";")
+}
+
+func normalizeSSPlugin(plugin string, pluginOpts string) (string, string) {
+	plugin = strings.TrimSpace(plugin)
+	pluginOpts = strings.TrimSpace(pluginOpts)
+	switch canonicalSSPluginName(plugin) {
+	case "obfs-local":
+		return "obfs-local", normalizeSimpleObfsOptions(pluginOpts)
+	default:
+		return plugin, pluginOpts
+	}
+}
+
+func canonicalSSPluginName(plugin string) string {
+	switch strings.ToLower(strings.TrimSpace(plugin)) {
+	case "obfs", "simple-obfs", "obfs-local":
+		return "obfs-local"
+	default:
+		return strings.ToLower(strings.TrimSpace(plugin))
+	}
+}
+
+func normalizeSimpleObfsOptions(pluginOpts string) string {
+	if pluginOpts == "" {
+		return ""
+	}
+	parts := splitUnescaped(pluginOpts, ';')
+	var obfsValue string
+	var hostValue string
+	extras := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		key, value, hasValue := cutUnescaped(part, '=')
+		if !hasValue {
+			if canonicalSSPluginName(part) == "obfs-local" {
+				continue
+			}
+			extras = append(extras, part)
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		switch strings.ToLower(key) {
+		case "mode", "obfs":
+			if value != "" && obfsValue == "" {
+				obfsValue = value
+			}
+		case "host", "obfs-host", "obfs_host":
+			if value != "" && hostValue == "" {
+				hostValue = value
+			}
+		default:
+			extras = append(extras, key+"="+value)
+		}
+	}
+	normalized := make([]string, 0, 2+len(extras))
+	if obfsValue != "" {
+		normalized = append(normalized, "obfs="+obfsValue)
+	}
+	if hostValue != "" {
+		normalized = append(normalized, "obfs-host="+hostValue)
+	}
+	normalized = append(normalized, extras...)
+	return strings.Join(normalized, ";")
+}
+
+func splitUnescaped(input string, delimiter byte) []string {
+	parts := make([]string, 0, 1)
+	start := 0
+	escaped := false
+	for i := 0; i < len(input); i++ {
+		switch {
+		case escaped:
+			escaped = false
+		case input[i] == '\\':
+			escaped = true
+		case input[i] == delimiter:
+			parts = append(parts, input[start:i])
+			start = i + 1
+		}
+	}
+	return append(parts, input[start:])
+}
+
+func cutUnescaped(input string, delimiter byte) (string, string, bool) {
+	escaped := false
+	for i := 0; i < len(input); i++ {
+		switch {
+		case escaped:
+			escaped = false
+		case input[i] == '\\':
+			escaped = true
+		case input[i] == delimiter:
+			return input[:i], input[i+1:], true
+		}
+	}
+	return input, "", false
 }
 
 func parsePositiveUint64(raw string) (uint64, bool) {
@@ -3839,6 +3945,7 @@ func setSSPluginFromClash(outbound map[string]any, proxy map[string]any) {
 	if plugin == "" {
 		return
 	}
+	plugin, pluginOpts = normalizeSSPlugin(plugin, pluginOpts)
 	outbound["plugin"] = plugin
 	if pluginOpts != "" {
 		outbound["plugin_opts"] = pluginOpts

--- a/internal/subscription/parser_test.go
+++ b/internal/subscription/parser_test.go
@@ -3,6 +3,7 @@ package subscription
 import (
 	"encoding/base64"
 	"encoding/json"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -1220,6 +1221,37 @@ func TestParseGeneralSubscription_SSDURI(t *testing.T) {
 	}
 }
 
+func TestParseGeneralSubscription_SSDURIWithSimpleObfsAlias(t *testing.T) {
+	ssd := `{
+		"airport":"SSD-Airport",
+		"port":8388,
+		"encryption":"aes-128-gcm",
+		"password":"default-pass",
+		"plugin":"simple-obfs",
+		"plugin_options":"mode=http;host=obfs.example.com",
+		"servers":[
+			{"server":"1.1.1.1","remarks":"ssd-obfs"}
+		]
+	}`
+	data := []byte("ssd://" + base64.StdEncoding.EncodeToString([]byte(ssd)))
+
+	nodes, err := ParseGeneralSubscription(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 parsed node, got %d", len(nodes))
+	}
+
+	obj := parseNodeRaw(t, nodes[0].RawOptions)
+	if got := obj["plugin"]; got != "obfs-local" {
+		t.Fatalf("plugin: got %v", got)
+	}
+	if got := obj["plugin_opts"]; got != "obfs=http;obfs-host=obfs.example.com" {
+		t.Fatalf("plugin_opts: got %v", got)
+	}
+}
+
 func TestParseGeneralSubscription_SurgeProxySection(t *testing.T) {
 	data := []byte(`
 [General]
@@ -1832,6 +1864,139 @@ func TestParseGeneralSubscription_SSURIWithPluginOptionsUnescapedSemicolons(t *t
 		t.Fatalf("plugin: got %v", got)
 	}
 	if got := obj["plugin_opts"]; got != "mode=websocket;host=ws.example.com;tls" {
+		t.Fatalf("plugin_opts: got %v", got)
+	}
+}
+
+func TestParseGeneralSubscription_SSURIWithSimpleObfsAlias(t *testing.T) {
+	data := []byte(
+		"ss://YWVzLTEyOC1nY206cGFzcw==@1.1.1.1:8388?plugin=simple-obfs%3Bobfs%3Dhttp%3Bobfs-host%3Dobfs.example.com#ss-simple-obfs",
+	)
+
+	nodes, err := ParseGeneralSubscription(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 parsed node, got %d", len(nodes))
+	}
+
+	obj := parseNodeRaw(t, nodes[0].RawOptions)
+	if got := obj["plugin"]; got != "obfs-local" {
+		t.Fatalf("plugin: got %v", got)
+	}
+	if got := obj["plugin_opts"]; got != "obfs=http;obfs-host=obfs.example.com" {
+		t.Fatalf("plugin_opts: got %v", got)
+	}
+}
+
+func TestParseGeneralSubscription_SSURIWithSeparatedSimpleObfsAliasOptions(t *testing.T) {
+	data := []byte(
+		"ss://YWVzLTEyOC1nY206cGFzcw==@1.1.1.1:8388?plugin=simple-obfs&plugin-opts=obfs-local%3Bmode%3Dhttp%3Bhost%3Dobfs.example.com#ss-simple-obfs-separated",
+	)
+
+	nodes, err := ParseGeneralSubscription(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 parsed node, got %d", len(nodes))
+	}
+
+	obj := parseNodeRaw(t, nodes[0].RawOptions)
+	if got := obj["plugin"]; got != "obfs-local" {
+		t.Fatalf("plugin: got %v", got)
+	}
+	if got := obj["plugin_opts"]; got != "obfs=http;obfs-host=obfs.example.com" {
+		t.Fatalf("plugin_opts: got %v", got)
+	}
+}
+
+func TestParseGeneralSubscription_SSURIWithSimpleObfsEscapedOptions(t *testing.T) {
+	plugin := url.QueryEscape(`simple-obfs;obfs=http;obfs-host=edge\;host.example.com;path=/a\=b`)
+	data := []byte("ss://YWVzLTEyOC1nY206cGFzcw==@1.1.1.1:8388?plugin=" + plugin + "#ss-simple-obfs-escaped")
+
+	nodes, err := ParseGeneralSubscription(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 parsed node, got %d", len(nodes))
+	}
+
+	obj := parseNodeRaw(t, nodes[0].RawOptions)
+	if got := obj["plugin"]; got != "obfs-local" {
+		t.Fatalf("plugin: got %v", got)
+	}
+	if got := obj["plugin_opts"]; got != `obfs=http;obfs-host=edge\;host.example.com;path=/a\=b` {
+		t.Fatalf("plugin_opts: got %v", got)
+	}
+}
+
+func TestParseGeneralSubscription_ClashSSWithObfsPluginAlias(t *testing.T) {
+	data := []byte(`{
+		"proxies": [{
+			"name": "tag-lax",
+			"type": "ss",
+			"server": "1.1.1.1",
+			"port": 8388,
+			"cipher": "aes-128-gcm",
+			"password": "pass",
+			"plugin": "obfs",
+			"plugin-opts": {
+				"mode": "http",
+				"host": "obfs.example.com"
+			}
+		}]
+	}`)
+
+	nodes, err := ParseGeneralSubscription(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 parsed node, got %d", len(nodes))
+	}
+
+	obj := parseNodeRaw(t, nodes[0].RawOptions)
+	if got := obj["plugin"]; got != "obfs-local" {
+		t.Fatalf("plugin: got %v", got)
+	}
+	if got := obj["plugin_opts"]; got != "obfs=http;obfs-host=obfs.example.com" {
+		t.Fatalf("plugin_opts: got %v", got)
+	}
+}
+
+func TestParseGeneralSubscription_ClashSSWithObfsLocalModeHostOptions(t *testing.T) {
+	data := []byte(`{
+		"proxies": [{
+			"name": "tag-lax",
+			"type": "ss",
+			"server": "1.1.1.1",
+			"port": 8388,
+			"cipher": "aes-128-gcm",
+			"password": "pass",
+			"plugin": "obfs-local",
+			"plugin-opts": {
+				"mode": "http",
+				"host": "obfs.example.com"
+			}
+		}]
+	}`)
+
+	nodes, err := ParseGeneralSubscription(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 parsed node, got %d", len(nodes))
+	}
+
+	obj := parseNodeRaw(t, nodes[0].RawOptions)
+	if got := obj["plugin"]; got != "obfs-local" {
+		t.Fatalf("plugin: got %v", got)
+	}
+	if got := obj["plugin_opts"]; got != "obfs=http;obfs-host=obfs.example.com" {
 		t.Fatalf("plugin_opts: got %v", got)
 	}
 }
@@ -2594,6 +2759,27 @@ func TestParseGeneralSubscription_NetchURI_SS(t *testing.T) {
 	}
 	if got := obj["method"]; got != "chacha20-ietf-poly1305" {
 		t.Fatalf("method: got %v", got)
+	}
+}
+
+func TestParseGeneralSubscription_NetchURI_SSWithObfsAlias(t *testing.T) {
+	payload := `{"Type":"SS","Remark":"Netch SS Obfs","Hostname":"1.1.1.1","Port":8388,"EncryptMethod":"AEAD_CHACHA20_POLY1305","Password":"pass","Plugin":"simple-obfs","PluginOption":"mode=http;host=obfs.example.com"}`
+	data := []byte("Netch://" + base64.StdEncoding.EncodeToString([]byte(payload)))
+
+	nodes, err := ParseGeneralSubscription(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 parsed node, got %d", len(nodes))
+	}
+
+	obj := parseNodeRaw(t, nodes[0].RawOptions)
+	if got := obj["plugin"]; got != "obfs-local" {
+		t.Fatalf("plugin: got %v", got)
+	}
+	if got := obj["plugin_opts"]; got != "obfs=http;obfs-host=obfs.example.com" {
+		t.Fatalf("plugin_opts: got %v", got)
 	}
 }
 


### PR DESCRIPTION
## 背景

部分 Shadowsocks 订阅会使用 `plugin: obfs` 或 `plugin: simple-obfs` 表达 simple-obfs 节点，并通过 `mode` / `host` 表达插件参数。

但 sing-box 当前支持的 SIP003 插件名是 `obfs-local`，如果 Resin 直接把订阅里的 `obfs` / `simple-obfs` 透传到出站配置，会导致节点运行时报错：

`plugin not found: obfs`

## 改动

- 将 Shadowsocks 插件别名统一归一化：
  - `obfs` -> `obfs-local`
  - `simple-obfs` -> `obfs-local`
  - `obfs-local` 保持为 `obfs-local`
- 将常见 simple-obfs 参数转换为 sing-box 可识别格式：
  - `mode` / `obfs` -> `obfs`
  - `host` / `obfs-host` / `obfs_host` -> `obfs-host`
- 覆盖 SS URI、Clash JSON/YAML、SSD URI、Netch URI。
- 保留未知额外插件参数。
- 保留 SIP003 `plugin_opts` 中转义的分号和等号，避免误切分 `\;` 或 `\=`。

## 测试补充

本 PR 同步补充了订阅解析测试用例，覆盖 simple-obfs 别名、分离参数格式、Clash/SSD/Netch 导入，以及 SIP003 转义参数边界。现有 `v2ray-plugin` 测试继续覆盖，确认非 simple-obfs 插件不会被误改写。

## 验证

已执行：

```bash
go test ./internal/subscription -count=1
go test ./...
git diff --check
```

## 关联问题

关联 #46。本次修复认为其中一类 Shadowsocks 节点熔断问题来自 simple-obfs 订阅格式兼容：订阅侧常见的 `obfs` / `simple-obfs`、`mode` / `host` 没有转换成 sing-box 需要的 `obfs-local`、`obfs` / `obfs-host`。

其他 Shadowsocks 失败场景后续可以按具体节点格式和运行错误继续排查。
