### PR TITLE
增加增量订阅开关

### DIFF
--- a/cmd/resin/main.go
+++ b/cmd/resin/main.go
@@ -386,17 +386,18 @@ func bootstrapTopology(
 	if err != nil {
 		return fmt.Errorf("load subscriptions: %w", err)
 	}
-	for _, ms := range dbSubs {
-		sub := subscription.NewSubscription(ms.ID, ms.Name, ms.URL, ms.Enabled, ms.Ephemeral)
-		sub.SetFetchConfig(ms.URL, ms.UpdateIntervalNs)
-		sub.SetSourceType(ms.SourceType)
-		sub.SetContent(ms.Content)
-		sub.SetEphemeralNodeEvictDelayNs(ms.EphemeralNodeEvictDelayNs)
-		sub.CreatedAtNs = ms.CreatedAtNs
-		sub.UpdatedAtNs = ms.UpdatedAtNs
-		subManager.Register(sub)
-	}
-	log.Printf("Loaded %d subscriptions from state.db", len(dbSubs))
+		for _, ms := range dbSubs {
+			sub := subscription.NewSubscription(ms.ID, ms.Name, ms.URL, ms.Enabled, ms.Ephemeral)
+			sub.SetFetchConfig(ms.URL, ms.UpdateIntervalNs)
+			sub.SetSourceType(ms.SourceType)
+			sub.SetContent(ms.Content)
+			sub.SetIncrementalAliveNodes(ms.IncrementalAliveNodes)
+			sub.SetEphemeralNodeEvictDelayNs(ms.EphemeralNodeEvictDelayNs)
+			sub.CreatedAtNs = ms.CreatedAtNs
+			sub.UpdatedAtNs = ms.UpdatedAtNs
+			subManager.Register(sub)
+		}
+		log.Printf("Loaded %d subscriptions from state.db", len(dbSubs))
 
 	dbPlats, err := engine.ListPlatforms()
 	if err != nil {

--- a/cmd/resin/main.go
+++ b/cmd/resin/main.go
@@ -386,18 +386,18 @@ func bootstrapTopology(
 	if err != nil {
 		return fmt.Errorf("load subscriptions: %w", err)
 	}
-		for _, ms := range dbSubs {
-			sub := subscription.NewSubscription(ms.ID, ms.Name, ms.URL, ms.Enabled, ms.Ephemeral)
-			sub.SetFetchConfig(ms.URL, ms.UpdateIntervalNs)
-			sub.SetSourceType(ms.SourceType)
-			sub.SetContent(ms.Content)
-			sub.SetIncrementalAliveNodes(ms.IncrementalAliveNodes)
-			sub.SetEphemeralNodeEvictDelayNs(ms.EphemeralNodeEvictDelayNs)
-			sub.CreatedAtNs = ms.CreatedAtNs
-			sub.UpdatedAtNs = ms.UpdatedAtNs
-			subManager.Register(sub)
-		}
-		log.Printf("Loaded %d subscriptions from state.db", len(dbSubs))
+	for _, ms := range dbSubs {
+		sub := subscription.NewSubscription(ms.ID, ms.Name, ms.URL, ms.Enabled, ms.Ephemeral)
+		sub.SetFetchConfig(ms.URL, ms.UpdateIntervalNs)
+		sub.SetSourceType(ms.SourceType)
+		sub.SetContent(ms.Content)
+		sub.SetIncrementalAliveNodes(ms.IncrementalAliveNodes)
+		sub.SetEphemeralNodeEvictDelayNs(ms.EphemeralNodeEvictDelayNs)
+		sub.CreatedAtNs = ms.CreatedAtNs
+		sub.UpdatedAtNs = ms.UpdatedAtNs
+		subManager.Register(sub)
+	}
+	log.Printf("Loaded %d subscriptions from state.db", len(dbSubs))
 
 	dbPlats, err := engine.ListPlatforms()
 	if err != nil {

--- a/internal/api/subscription_local_contract_test.go
+++ b/internal/api/subscription_local_contract_test.go
@@ -9,8 +9,9 @@ func TestAPIContract_SubscriptionLocalCreateValidation(t *testing.T) {
 	srv, _, _ := newControlPlaneTestServer(t)
 
 	rec := doJSONRequest(t, srv, http.MethodPost, "/api/v1/subscriptions", map[string]any{
-		"name":        "sub-local",
+		"name": "sub-local",
 		"source_type": "local",
+		"incremental_alive_nodes": true,
 	}, true)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("create local without content status: got %d, want %d, body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())

--- a/internal/api/subscription_local_contract_test.go
+++ b/internal/api/subscription_local_contract_test.go
@@ -9,8 +9,8 @@ func TestAPIContract_SubscriptionLocalCreateValidation(t *testing.T) {
 	srv, _, _ := newControlPlaneTestServer(t)
 
 	rec := doJSONRequest(t, srv, http.MethodPost, "/api/v1/subscriptions", map[string]any{
-		"name": "sub-local",
-		"source_type": "local",
+		"name":                    "sub-local",
+		"source_type":             "local",
 		"incremental_alive_nodes": true,
 	}, true)
 	if rec.Code != http.StatusBadRequest {

--- a/internal/api/subscription_refresh_e2e_test.go
+++ b/internal/api/subscription_refresh_e2e_test.go
@@ -45,6 +45,7 @@ func TestAPIContract_SubscriptionRefreshAction_E2EHTTPSource(t *testing.T) {
 	createRec := doJSONRequest(t, srv, http.MethodPost, "/api/v1/subscriptions", map[string]any{
 		"name": "sub-e2e",
 		"url":  subscriptionSource.URL + "/sub",
+		"incremental_alive_nodes": true,
 	}, true)
 	if createRec.Code != http.StatusCreated {
 		t.Fatalf("create subscription status: got %d, want %d, body=%s", createRec.Code, http.StatusCreated, createRec.Body.String())
@@ -59,6 +60,9 @@ func TestAPIContract_SubscriptionRefreshAction_E2EHTTPSource(t *testing.T) {
 	}
 	if got := createBody["healthy_node_count"]; got != float64(0) {
 		t.Fatalf("create subscription healthy_node_count: got %v, want %v", got, 0)
+	}
+	if got := createBody["incremental_alive_nodes"]; got != true {
+		t.Fatalf("create subscription incremental_alive_nodes: got %v, want %v", got, true)
 	}
 
 	refreshRec := doJSONRequest(

--- a/internal/api/subscription_refresh_e2e_test.go
+++ b/internal/api/subscription_refresh_e2e_test.go
@@ -43,8 +43,8 @@ func TestAPIContract_SubscriptionRefreshAction_E2EHTTPSource(t *testing.T) {
 	})
 
 	createRec := doJSONRequest(t, srv, http.MethodPost, "/api/v1/subscriptions", map[string]any{
-		"name": "sub-e2e",
-		"url":  subscriptionSource.URL + "/sub",
+		"name":                    "sub-e2e",
+		"url":                     subscriptionSource.URL + "/sub",
 		"incremental_alive_nodes": true,
 	}, true)
 	if createRec.Code != http.StatusCreated {

--- a/internal/model/models.go
+++ b/internal/model/models.go
@@ -27,6 +27,7 @@ type Subscription struct {
 	UpdateIntervalNs          int64  `json:"update_interval_ns"`
 	Enabled                   bool   `json:"enabled"`
 	Ephemeral                 bool   `json:"ephemeral"`
+	IncrementalAliveNodes     bool   `json:"incremental_alive_nodes"`
 	EphemeralNodeEvictDelayNs int64  `json:"ephemeral_node_evict_delay_ns"`
 	CreatedAtNs               int64  `json:"created_at_ns"`
 	UpdatedAtNs               int64  `json:"updated_at_ns"`

--- a/internal/service/control_plane_subscription.go
+++ b/internal/service/control_plane_subscription.go
@@ -31,6 +31,7 @@ type SubscriptionResponse struct {
 	NodeCount               int    `json:"node_count"`
 	HealthyNodeCount        int    `json:"healthy_node_count"`
 	Ephemeral               bool   `json:"ephemeral"`
+	IncrementalAliveNodes   bool   `json:"incremental_alive_nodes"`
 	EphemeralNodeEvictDelay string `json:"ephemeral_node_evict_delay"`
 	Enabled                 bool   `json:"enabled"`
 	CreatedAt               string `json:"created_at"`
@@ -63,18 +64,19 @@ func (s *ControlPlaneService) subToResponse(sub *subscription.Subscription) Subs
 	}
 
 	resp := SubscriptionResponse{
-		ID:                      sub.ID,
-		Name:                    sub.Name(),
-		SourceType:              sub.SourceType(),
-		URL:                     sub.URL(),
-		Content:                 sub.Content(),
-		UpdateInterval:          time.Duration(sub.UpdateIntervalNs()).String(),
-		NodeCount:               nodeCount,
-		HealthyNodeCount:        healthyNodeCount,
-		Ephemeral:               sub.Ephemeral(),
+		ID:                    sub.ID,
+		Name:                  sub.Name(),
+		SourceType:            sub.SourceType(),
+		URL:                   sub.URL(),
+		Content:               sub.Content(),
+		UpdateInterval:        time.Duration(sub.UpdateIntervalNs()).String(),
+		NodeCount:             nodeCount,
+		HealthyNodeCount:      healthyNodeCount,
+		Ephemeral:             sub.Ephemeral(),
+		IncrementalAliveNodes: sub.IncrementalAliveNodes(),
 		EphemeralNodeEvictDelay: time.Duration(sub.EphemeralNodeEvictDelayNs()).String(),
-		Enabled:                 sub.Enabled(),
-		CreatedAt:               time.Unix(0, sub.CreatedAtNs).UTC().Format(time.RFC3339Nano),
+		Enabled:               sub.Enabled(),
+		CreatedAt:             time.Unix(0, sub.CreatedAtNs).UTC().Format(time.RFC3339Nano),
 	}
 	if lc := sub.LastCheckedNs.Load(); lc > 0 {
 		resp.LastChecked = time.Unix(0, lc).UTC().Format(time.RFC3339Nano)
@@ -114,13 +116,14 @@ func (s *ControlPlaneService) GetSubscription(id string) (*SubscriptionResponse,
 
 // CreateSubscriptionRequest holds create subscription parameters.
 type CreateSubscriptionRequest struct {
-	Name                    *string `json:"name"`
-	SourceType              *string `json:"source_type"`
-	URL                     *string `json:"url"`
-	Content                 *string `json:"content"`
-	UpdateInterval          *string `json:"update_interval"`
-	Enabled                 *bool   `json:"enabled"`
-	Ephemeral               *bool   `json:"ephemeral"`
+	Name                  *string `json:"name"`
+	SourceType            *string `json:"source_type"`
+	URL                   *string `json:"url"`
+	Content               *string `json:"content"`
+	UpdateInterval        *string `json:"update_interval"`
+	Enabled               *bool   `json:"enabled"`
+	Ephemeral             *bool   `json:"ephemeral"`
+	IncrementalAliveNodes *bool   `json:"incremental_alive_nodes"`
 	EphemeralNodeEvictDelay *string `json:"ephemeral_node_evict_delay"`
 }
 
@@ -198,6 +201,10 @@ func (s *ControlPlaneService) CreateSubscription(req CreateSubscriptionRequest) 
 	if req.Ephemeral != nil {
 		ephemeral = *req.Ephemeral
 	}
+	incrementalAliveNodes := false
+	if req.IncrementalAliveNodes != nil {
+		incrementalAliveNodes = *req.IncrementalAliveNodes
+	}
 	ephemeralNodeEvictDelay := defaultSubscriptionEphemeralNodeEvictDelay
 	if req.EphemeralNodeEvictDelay != nil {
 		d, err := time.ParseDuration(*req.EphemeralNodeEvictDelay)
@@ -222,6 +229,7 @@ func (s *ControlPlaneService) CreateSubscription(req CreateSubscriptionRequest) 
 		UpdateIntervalNs:          int64(updateInterval),
 		Enabled:                   enabled,
 		Ephemeral:                 ephemeral,
+		IncrementalAliveNodes:     incrementalAliveNodes,
 		EphemeralNodeEvictDelayNs: int64(ephemeralNodeEvictDelay),
 		CreatedAtNs:               now,
 		UpdatedAtNs:               now,
@@ -234,6 +242,7 @@ func (s *ControlPlaneService) CreateSubscription(req CreateSubscriptionRequest) 
 	sub.SetFetchConfig(subURL, int64(updateInterval))
 	sub.SetSourceType(sourceType)
 	sub.SetContent(content)
+	sub.SetIncrementalAliveNodes(incrementalAliveNodes)
 	sub.SetEphemeralNodeEvictDelayNs(int64(ephemeralNodeEvictDelay))
 	sub.CreatedAtNs = now
 	sub.UpdatedAtNs = now
@@ -338,6 +347,13 @@ func (s *ControlPlaneService) UpdateSubscription(id string, patchJSON json.RawMe
 		newEphemeral = b
 	}
 
+	newIncrementalAliveNodes := sub.IncrementalAliveNodes()
+	if b, ok, err := patch.optionalBool("incremental_alive_nodes"); err != nil {
+		return nil, err
+	} else if ok {
+		newIncrementalAliveNodes = b
+	}
+
 	newEphemeralNodeEvictDelay := sub.EphemeralNodeEvictDelayNs()
 	if d, ok, err := patch.optionalDurationString("ephemeral_node_evict_delay"); err != nil {
 		return nil, err
@@ -358,6 +374,7 @@ func (s *ControlPlaneService) UpdateSubscription(id string, patchJSON json.RawMe
 		UpdateIntervalNs:          newInterval,
 		Enabled:                   newEnabled,
 		Ephemeral:                 newEphemeral,
+		IncrementalAliveNodes:     newIncrementalAliveNodes,
 		EphemeralNodeEvictDelayNs: newEphemeralNodeEvictDelay,
 		CreatedAtNs:               sub.CreatedAtNs,
 		UpdatedAtNs:               now,
@@ -370,6 +387,7 @@ func (s *ControlPlaneService) UpdateSubscription(id string, patchJSON json.RawMe
 	sub.SetFetchConfig(newURL, newInterval)
 	sub.SetContent(newContent)
 	sub.SetEphemeral(newEphemeral)
+	sub.SetIncrementalAliveNodes(newIncrementalAliveNodes)
 	sub.SetEphemeralNodeEvictDelayNs(newEphemeralNodeEvictDelay)
 	sub.UpdatedAtNs = now
 

--- a/internal/service/control_plane_subscription.go
+++ b/internal/service/control_plane_subscription.go
@@ -64,19 +64,19 @@ func (s *ControlPlaneService) subToResponse(sub *subscription.Subscription) Subs
 	}
 
 	resp := SubscriptionResponse{
-		ID:                    sub.ID,
-		Name:                  sub.Name(),
-		SourceType:            sub.SourceType(),
-		URL:                   sub.URL(),
-		Content:               sub.Content(),
-		UpdateInterval:        time.Duration(sub.UpdateIntervalNs()).String(),
-		NodeCount:             nodeCount,
-		HealthyNodeCount:      healthyNodeCount,
-		Ephemeral:             sub.Ephemeral(),
-		IncrementalAliveNodes: sub.IncrementalAliveNodes(),
+		ID:                      sub.ID,
+		Name:                    sub.Name(),
+		SourceType:              sub.SourceType(),
+		URL:                     sub.URL(),
+		Content:                 sub.Content(),
+		UpdateInterval:          time.Duration(sub.UpdateIntervalNs()).String(),
+		NodeCount:               nodeCount,
+		HealthyNodeCount:        healthyNodeCount,
+		Ephemeral:               sub.Ephemeral(),
+		IncrementalAliveNodes:   sub.IncrementalAliveNodes(),
 		EphemeralNodeEvictDelay: time.Duration(sub.EphemeralNodeEvictDelayNs()).String(),
-		Enabled:               sub.Enabled(),
-		CreatedAt:             time.Unix(0, sub.CreatedAtNs).UTC().Format(time.RFC3339Nano),
+		Enabled:                 sub.Enabled(),
+		CreatedAt:               time.Unix(0, sub.CreatedAtNs).UTC().Format(time.RFC3339Nano),
 	}
 	if lc := sub.LastCheckedNs.Load(); lc > 0 {
 		resp.LastChecked = time.Unix(0, lc).UTC().Format(time.RFC3339Nano)
@@ -116,14 +116,14 @@ func (s *ControlPlaneService) GetSubscription(id string) (*SubscriptionResponse,
 
 // CreateSubscriptionRequest holds create subscription parameters.
 type CreateSubscriptionRequest struct {
-	Name                  *string `json:"name"`
-	SourceType            *string `json:"source_type"`
-	URL                   *string `json:"url"`
-	Content               *string `json:"content"`
-	UpdateInterval        *string `json:"update_interval"`
-	Enabled               *bool   `json:"enabled"`
-	Ephemeral             *bool   `json:"ephemeral"`
-	IncrementalAliveNodes *bool   `json:"incremental_alive_nodes"`
+	Name                    *string `json:"name"`
+	SourceType              *string `json:"source_type"`
+	URL                     *string `json:"url"`
+	Content                 *string `json:"content"`
+	UpdateInterval          *string `json:"update_interval"`
+	Enabled                 *bool   `json:"enabled"`
+	Ephemeral               *bool   `json:"ephemeral"`
+	IncrementalAliveNodes   *bool   `json:"incremental_alive_nodes"`
 	EphemeralNodeEvictDelay *string `json:"ephemeral_node_evict_delay"`
 }
 

--- a/internal/service/control_plane_system.go
+++ b/internal/service/control_plane_system.go
@@ -101,12 +101,13 @@ var platformPatchAllowedFields = map[string]bool{
 }
 
 var subscriptionPatchAllowedFields = map[string]bool{
-	"name":                       true,
-	"url":                        true,
-	"content":                    true,
-	"update_interval":            true,
-	"enabled":                    true,
-	"ephemeral":                  true,
+	"name":                    true,
+	"url":                     true,
+	"content":                 true,
+	"update_interval":         true,
+	"enabled":                 true,
+	"ephemeral":               true,
+	"incremental_alive_nodes": true,
 	"ephemeral_node_evict_delay": true,
 }
 

--- a/internal/service/control_plane_system.go
+++ b/internal/service/control_plane_system.go
@@ -101,13 +101,13 @@ var platformPatchAllowedFields = map[string]bool{
 }
 
 var subscriptionPatchAllowedFields = map[string]bool{
-	"name":                    true,
-	"url":                     true,
-	"content":                 true,
-	"update_interval":         true,
-	"enabled":                 true,
-	"ephemeral":               true,
-	"incremental_alive_nodes": true,
+	"name":                       true,
+	"url":                        true,
+	"content":                    true,
+	"update_interval":            true,
+	"enabled":                    true,
+	"ephemeral":                  true,
+	"incremental_alive_nodes":    true,
 	"ephemeral_node_evict_delay": true,
 }
 

--- a/internal/state/migrate.go
+++ b/internal/state/migrate.go
@@ -19,11 +19,12 @@ const (
 	// Keep these version markers in sync with SQL files under migrations/state/.
 	// stateLegacyBaselineVersion must remain fixed to the highest migration
 	// version covered by compatibility detection for pre-migrate databases.
-	stateVersionBaseSchema              = 1
-	stateVersionAddEmptyAccountBehavior = 2
-	stateVersionAddFixedAccountHeader   = 3
-	stateVersionNormalizeMissAction     = 4
-	stateLegacyBaselineVersion          = stateVersionAddFixedAccountHeader
+	stateVersionBaseSchema               = 1
+	stateVersionAddEmptyAccountBehavior  = 2
+	stateVersionAddFixedAccountHeader    = 3
+	stateVersionNormalizeMissAction      = 4
+	stateVersionAddIncrementalAliveNodes = 5
+	stateLegacyBaselineVersion           = stateVersionAddFixedAccountHeader
 )
 
 //go:embed migrations/state/*.sql migrations/cache/*.sql
@@ -104,8 +105,14 @@ func prepareLegacyStateBaseline(db *sql.DB, driver migratedb.Driver) error {
 	if err != nil {
 		return err
 	}
+	hasIncrementalAliveNodes, err := hasTableColumn(db, "subscriptions", "incremental_alive_nodes")
+	if err != nil {
+		return err
+	}
 
 	switch {
+	case hasEmptyBehavior && hasFixedHeader && hasIncrementalAliveNodes:
+		return setMigrationVersion(driver, stateVersionAddIncrementalAliveNodes)
 	case hasEmptyBehavior && hasFixedHeader:
 		return setMigrationVersion(driver, stateLegacyBaselineVersion)
 	case hasEmptyBehavior && !hasFixedHeader:

--- a/internal/state/migrate.go
+++ b/internal/state/migrate.go
@@ -25,6 +25,8 @@ const (
 	stateVersionNormalizeMissAction      = 4
 	stateVersionAddIncrementalAliveNodes = 5
 	stateLegacyBaselineVersion           = stateVersionAddFixedAccountHeader
+
+	stateBaseSchemaMigration = stateMigrationsPath + "/000001_state_base.up.sql"
 )
 
 //go:embed migrations/state/*.sql migrations/cache/*.sql
@@ -112,11 +114,11 @@ func prepareLegacyStateBaseline(db *sql.DB, driver migratedb.Driver) error {
 
 	switch {
 	case hasEmptyBehavior && hasFixedHeader && hasIncrementalAliveNodes:
-		return setMigrationVersion(driver, stateVersionAddIncrementalAliveNodes)
+		return setLegacyMigrationVersion(db, driver, stateVersionAddIncrementalAliveNodes)
 	case hasEmptyBehavior && hasFixedHeader:
-		return setMigrationVersion(driver, stateLegacyBaselineVersion)
+		return setLegacyMigrationVersion(db, driver, stateLegacyBaselineVersion)
 	case hasEmptyBehavior && !hasFixedHeader:
-		return setMigrationVersion(driver, stateVersionAddEmptyAccountBehavior)
+		return setLegacyMigrationVersion(db, driver, stateVersionAddEmptyAccountBehavior)
 	case !hasEmptyBehavior && hasFixedHeader:
 		// This mixed state should not happen in normal upgrades. Repair it once.
 		if err := ensureTableColumn(
@@ -127,7 +129,7 @@ func prepareLegacyStateBaseline(db *sql.DB, driver migratedb.Driver) error {
 		); err != nil {
 			return err
 		}
-		return setMigrationVersion(driver, stateLegacyBaselineVersion)
+		return setLegacyMigrationVersion(db, driver, stateLegacyBaselineVersion)
 	default:
 		// No baseline metadata: migrate from base schema.
 		return nil
@@ -145,6 +147,24 @@ func hasMigrationVersion(db *sql.DB, table string) (bool, error) {
 func setMigrationVersion(driver migratedb.Driver, version int) error {
 	if err := driver.SetVersion(version, false); err != nil {
 		return fmt.Errorf("set migration version=%d: %w", version, err)
+	}
+	return nil
+}
+
+func setLegacyMigrationVersion(db *sql.DB, driver migratedb.Driver, version int) error {
+	if err := ensureStateBaseSchema(db); err != nil {
+		return err
+	}
+	return setMigrationVersion(driver, version)
+}
+
+func ensureStateBaseSchema(db *sql.DB) error {
+	schema, err := migrationsFS.ReadFile(stateBaseSchemaMigration)
+	if err != nil {
+		return fmt.Errorf("read state base schema: %w", err)
+	}
+	if _, err := db.Exec(string(schema)); err != nil {
+		return fmt.Errorf("ensure state base schema: %w", err)
 	}
 	return nil
 }

--- a/internal/state/migrations/state/000005_subscriptions_add_incremental_alive_nodes.down.sql
+++ b/internal/state/migrations/state/000005_subscriptions_add_incremental_alive_nodes.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE subscriptions DROP COLUMN incremental_alive_nodes;

--- a/internal/state/migrations/state/000005_subscriptions_add_incremental_alive_nodes.up.sql
+++ b/internal/state/migrations/state/000005_subscriptions_add_incremental_alive_nodes.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE subscriptions ADD COLUMN incremental_alive_nodes INTEGER NOT NULL DEFAULT 0;

--- a/internal/state/repo_state.go
+++ b/internal/state/repo_state.go
@@ -299,21 +299,22 @@ func (r *StateRepo) UpsertSubscription(s model.Subscription) error {
 	defer r.mu.Unlock()
 
 	_, err := r.db.Exec(`
-		INSERT INTO subscriptions (id, name, source_type, url, content, update_interval_ns, enabled,
-		                           ephemeral, ephemeral_node_evict_delay_ns, created_at_ns, updated_at_ns)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(id) DO UPDATE SET
-			name               = excluded.name,
-			source_type        = excluded.source_type,
-			url                = excluded.url,
-			content            = excluded.content,
-			update_interval_ns = excluded.update_interval_ns,
-			enabled            = excluded.enabled,
-			ephemeral          = excluded.ephemeral,
-			ephemeral_node_evict_delay_ns = excluded.ephemeral_node_evict_delay_ns,
-			updated_at_ns      = excluded.updated_at_ns
-	`, s.ID, s.Name, s.SourceType, s.URL, s.Content, s.UpdateIntervalNs, s.Enabled,
-		s.Ephemeral, s.EphemeralNodeEvictDelayNs, s.CreatedAtNs, s.UpdatedAtNs)
+			INSERT INTO subscriptions (id, name, source_type, url, content, update_interval_ns, enabled,
+			                           ephemeral, incremental_alive_nodes, ephemeral_node_evict_delay_ns, created_at_ns, updated_at_ns)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(id) DO UPDATE SET
+				name               = excluded.name,
+				source_type        = excluded.source_type,
+				url                = excluded.url,
+				content            = excluded.content,
+				update_interval_ns = excluded.update_interval_ns,
+				enabled            = excluded.enabled,
+				ephemeral          = excluded.ephemeral,
+				incremental_alive_nodes = excluded.incremental_alive_nodes,
+				ephemeral_node_evict_delay_ns = excluded.ephemeral_node_evict_delay_ns,
+				updated_at_ns      = excluded.updated_at_ns
+		`, s.ID, s.Name, s.SourceType, s.URL, s.Content, s.UpdateIntervalNs, s.Enabled,
+			s.Ephemeral, s.IncrementalAliveNodes, s.EphemeralNodeEvictDelayNs, s.CreatedAtNs, s.UpdatedAtNs)
 	return err
 }
 
@@ -336,7 +337,7 @@ func (r *StateRepo) DeleteSubscription(id string) error {
 // ListSubscriptions returns all subscriptions.
 func (r *StateRepo) ListSubscriptions() ([]model.Subscription, error) {
 	rows, err := r.db.Query(`SELECT id, name, source_type, url, content, update_interval_ns, enabled,
-		ephemeral, ephemeral_node_evict_delay_ns, created_at_ns, updated_at_ns FROM subscriptions`)
+		ephemeral, incremental_alive_nodes, ephemeral_node_evict_delay_ns, created_at_ns, updated_at_ns FROM subscriptions`)
 	if err != nil {
 		return nil, err
 	}
@@ -346,7 +347,7 @@ func (r *StateRepo) ListSubscriptions() ([]model.Subscription, error) {
 	for rows.Next() {
 		var s model.Subscription
 		if err := rows.Scan(&s.ID, &s.Name, &s.SourceType, &s.URL, &s.Content, &s.UpdateIntervalNs, &s.Enabled,
-			&s.Ephemeral, &s.EphemeralNodeEvictDelayNs, &s.CreatedAtNs, &s.UpdatedAtNs); err != nil {
+			&s.Ephemeral, &s.IncrementalAliveNodes, &s.EphemeralNodeEvictDelayNs, &s.CreatedAtNs, &s.UpdatedAtNs); err != nil {
 			return nil, err
 		}
 		if s.SourceType == "" {

--- a/internal/state/repo_state.go
+++ b/internal/state/repo_state.go
@@ -314,7 +314,7 @@ func (r *StateRepo) UpsertSubscription(s model.Subscription) error {
 				ephemeral_node_evict_delay_ns = excluded.ephemeral_node_evict_delay_ns,
 				updated_at_ns      = excluded.updated_at_ns
 		`, s.ID, s.Name, s.SourceType, s.URL, s.Content, s.UpdateIntervalNs, s.Enabled,
-			s.Ephemeral, s.IncrementalAliveNodes, s.EphemeralNodeEvictDelayNs, s.CreatedAtNs, s.UpdatedAtNs)
+		s.Ephemeral, s.IncrementalAliveNodes, s.EphemeralNodeEvictDelayNs, s.CreatedAtNs, s.UpdatedAtNs)
 	return err
 }
 

--- a/internal/state/repo_state_test.go
+++ b/internal/state/repo_state_test.go
@@ -103,8 +103,72 @@ func TestMigrateStateDB_LegacyBaselineAdvancesToLatest(t *testing.T) {
 	if dirty {
 		t.Fatalf("schema_migrations dirty=true")
 	}
-	if version != stateVersionNormalizeMissAction {
-		t.Fatalf("schema_migrations version: got %d, want %d", version, stateVersionNormalizeMissAction)
+	if version != stateVersionAddIncrementalAliveNodes {
+		t.Fatalf("schema_migrations version: got %d, want %d", version, stateVersionAddIncrementalAliveNodes)
+	}
+	if ok, err := hasTableColumn(db, "subscriptions", "incremental_alive_nodes"); err != nil || !ok {
+		t.Fatalf("expected migrated column subscriptions.incremental_alive_nodes, ok=%v err=%v", ok, err)
+	}
+}
+
+func TestMigrateStateDB_AddsIncrementalAliveNodesToLegacySubscriptions(t *testing.T) {
+	dir := t.TempDir()
+	db, err := OpenDB(dir + "/state.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec(`
+		CREATE TABLE platforms (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL UNIQUE,
+			sticky_ttl_ns INTEGER NOT NULL,
+			regex_filters_json TEXT NOT NULL DEFAULT '[]',
+			region_filters_json TEXT NOT NULL DEFAULT '[]',
+			reverse_proxy_miss_action TEXT NOT NULL DEFAULT 'RANDOM',
+			reverse_proxy_empty_account_behavior TEXT NOT NULL DEFAULT 'RANDOM',
+			reverse_proxy_fixed_account_header TEXT NOT NULL DEFAULT '',
+			allocation_policy TEXT NOT NULL DEFAULT 'BALANCED',
+			updated_at_ns INTEGER NOT NULL
+		);
+
+		CREATE TABLE subscriptions (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			source_type TEXT NOT NULL DEFAULT 'remote',
+			url TEXT NOT NULL,
+			content TEXT NOT NULL DEFAULT '',
+			update_interval_ns INTEGER NOT NULL,
+			enabled INTEGER NOT NULL DEFAULT 1,
+			ephemeral INTEGER NOT NULL DEFAULT 0,
+			ephemeral_node_evict_delay_ns INTEGER NOT NULL,
+			created_at_ns INTEGER NOT NULL,
+			updated_at_ns INTEGER NOT NULL
+		)
+	`)
+	if err != nil {
+		t.Fatalf("create legacy platforms and subscriptions tables: %v", err)
+	}
+
+	if err := MigrateStateDB(db); err != nil {
+		t.Fatalf("MigrateStateDB: %v", err)
+	}
+
+	if ok, err := hasTableColumn(db, "subscriptions", "incremental_alive_nodes"); err != nil || !ok {
+		t.Fatalf("expected migrated column subscriptions.incremental_alive_nodes, ok=%v err=%v", ok, err)
+	}
+
+	var version int
+	var dirty bool
+	if err := db.QueryRow("SELECT version, dirty FROM schema_migrations LIMIT 1").Scan(&version, &dirty); err != nil {
+		t.Fatalf("read schema_migrations: %v", err)
+	}
+	if dirty {
+		t.Fatalf("schema_migrations dirty=true")
+	}
+	if version != stateVersionAddIncrementalAliveNodes {
+		t.Fatalf("schema_migrations version: got %d, want %d", version, stateVersionAddIncrementalAliveNodes)
 	}
 }
 
@@ -175,8 +239,11 @@ func TestMigrateStateDB_NormalizesLegacyRandomMissAction(t *testing.T) {
 	if dirty {
 		t.Fatalf("schema_migrations dirty=true")
 	}
-	if version != stateVersionNormalizeMissAction {
-		t.Fatalf("schema_migrations version: got %d, want %d", version, stateVersionNormalizeMissAction)
+	if version != stateVersionAddIncrementalAliveNodes {
+		t.Fatalf("schema_migrations version: got %d, want %d", version, stateVersionAddIncrementalAliveNodes)
+	}
+	if ok, err := hasTableColumn(db, "subscriptions", "incremental_alive_nodes"); err != nil || !ok {
+		t.Fatalf("expected migrated column subscriptions.incremental_alive_nodes, ok=%v err=%v", ok, err)
 	}
 }
 

--- a/internal/subscription/subscription.go
+++ b/internal/subscription/subscription.go
@@ -19,6 +19,13 @@ const (
 	SourceTypeLocal = "local"
 )
 
+const (
+	// UpdateModeReplace replaces current subscription nodes with refreshed content.
+	UpdateModeReplace = false
+	// UpdateModeIncrementalAlive keeps existing non-evicted nodes and merges refreshed content.
+	UpdateModeIncrementalAlive = true
+)
+
 // ManagedNode represents one hash entry in subscription managed nodes.
 type ManagedNode struct {
 	Tags    []string
@@ -114,10 +121,11 @@ type Subscription struct {
 	sourceType string
 	content    string
 	// updateIntervalNs is the configured subscription refresh interval.
-	updateIntervalNs int64
-	name             string
-	enabled          bool
-	ephemeral        bool
+	updateIntervalNs      int64
+	name                  string
+	enabled               bool
+	ephemeral             bool
+	incrementalAliveNodes bool
 	// ephemeralNodeEvictDelayNs is the per-subscription eviction delay for
 	// circuit-broken nodes when Ephemeral is enabled.
 	ephemeralNodeEvictDelayNs int64
@@ -131,6 +139,10 @@ type Subscription struct {
 	LastCheckedNs atomic.Int64
 	LastUpdatedNs atomic.Int64
 	LastError     atomic.Pointer[string]
+
+	// Scheduler sequencing for stale-attempt guards.
+	attemptSeq     atomic.Int64
+	lastAppliedSeq atomic.Int64
 
 	// managedNodes is the subscription's node view: Hash → ManagedNode.
 	// Swapped atomically on subscription update.
@@ -150,6 +162,7 @@ func NewSubscription(id, name, url string, enabled, ephemeral bool) *Subscriptio
 		name:                      name,
 		enabled:                   enabled,
 		ephemeral:                 ephemeral,
+		incrementalAliveNodes:     UpdateModeReplace,
 		ephemeralNodeEvictDelayNs: defaultEphemeralNodeEvictDelayNs,
 	}
 	empty := NewManagedNodes()
@@ -165,6 +178,15 @@ func (s *Subscription) SetLastError(err string) { s.LastError.Store(&err) }
 
 // GetLastError atomically loads the last error string.
 func (s *Subscription) GetLastError() string { return *s.LastError.Load() }
+
+// NextAttemptSeq returns a strictly increasing sequence for refresh attempts.
+func (s *Subscription) NextAttemptSeq() int64 { return s.attemptSeq.Add(1) }
+
+// LastAppliedSeq returns the latest applied refresh attempt sequence.
+func (s *Subscription) LastAppliedSeq() int64 { return s.lastAppliedSeq.Load() }
+
+// MarkAppliedAttempt records the latest applied refresh attempt sequence.
+func (s *Subscription) MarkAppliedAttempt(seq int64) { s.lastAppliedSeq.Store(seq) }
 
 // WithOpLock runs fn under the subscription operation lock.
 func (s *Subscription) WithOpLock(fn func()) {
@@ -278,6 +300,20 @@ func (s *Subscription) Ephemeral() bool {
 func (s *Subscription) SetEphemeral(v bool) {
 	s.mu.Lock()
 	s.ephemeral = v
+	s.mu.Unlock()
+}
+
+// IncrementalAliveNodes returns whether refresh keeps existing non-evicted nodes (thread-safe).
+func (s *Subscription) IncrementalAliveNodes() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.incrementalAliveNodes
+}
+
+// SetIncrementalAliveNodes updates the refresh merge mode (thread-safe).
+func (s *Subscription) SetIncrementalAliveNodes(v bool) {
+	s.mu.Lock()
+	s.incrementalAliveNodes = v
 	s.mu.Unlock()
 }
 

--- a/internal/topology/scheduler_test.go
+++ b/internal/topology/scheduler_test.go
@@ -353,6 +353,80 @@ func TestScheduler_UpdateSubscription_KeepEvictedDoesNotReAddToPool(t *testing.T
 	}
 }
 
+func TestScheduler_UpdateSubscription_IncrementalAliveModeKeepsHealthyOldNodes(t *testing.T) {
+	subMgr := NewSubscriptionManager()
+	sub := subscription.NewSubscription("s1", "TestSub", "http://example.com", true, false)
+	sub.SetIncrementalAliveNodes(true)
+	subMgr.Register(sub)
+
+	pool := newTestPool(subMgr)
+	initialRaw := `{"type":"shadowsocks","tag":"healthy-old","server":"1.1.1.1","server_port":443}`
+	sched := newTestScheduler(subMgr, pool, makeMockFetcher(makeSubscriptionJSON(initialRaw), nil))
+	sched.UpdateSubscription(sub)
+
+	oldHash := node.HashFromRawOptions([]byte(initialRaw))
+	oldEntry, ok := pool.GetEntry(oldHash)
+	if !ok {
+		t.Fatal("old node should exist after initial refresh")
+	}
+	outbound := testutil.NewNoopOutbound()
+	oldEntry.Outbound.Store(&outbound)
+	oldEntry.CircuitOpenSince.Store(0)
+	oldEntry.SetLastError("")
+
+	newRaw := `{"type":"vmess","tag":"new-node","server":"2.2.2.2","server_port":443}`
+	sched.Fetcher = makeMockFetcher(makeSubscriptionJSON(newRaw), nil)
+	sched.UpdateSubscription(sub)
+
+	newHash := node.HashFromRawOptions([]byte(newRaw))
+	if _, ok := sub.ManagedNodes().LoadNode(oldHash); !ok {
+		t.Fatal("healthy old node should be retained in incremental mode")
+	}
+	if _, ok := sub.ManagedNodes().LoadNode(newHash); !ok {
+		t.Fatal("new node should be present after incremental refresh")
+	}
+	if _, ok := pool.GetEntry(oldHash); !ok {
+		t.Fatal("healthy old node should remain in pool")
+	}
+	if _, ok := pool.GetEntry(newHash); !ok {
+		t.Fatal("new node should be added to pool")
+	}
+}
+
+func TestScheduler_UpdateSubscription_IncrementalAliveModeRemovesUnhealthyOldNodes(t *testing.T) {
+	subMgr := NewSubscriptionManager()
+	sub := subscription.NewSubscription("s1", "TestSub", "http://example.com", true, false)
+	sub.SetIncrementalAliveNodes(true)
+	subMgr.Register(sub)
+
+	pool := newTestPool(subMgr)
+	initialRaw := `{"type":"shadowsocks","tag":"bad-old","server":"1.1.1.1","server_port":443}`
+	sched := newTestScheduler(subMgr, pool, makeMockFetcher(makeSubscriptionJSON(initialRaw), nil))
+	sched.UpdateSubscription(sub)
+
+	oldHash := node.HashFromRawOptions([]byte(initialRaw))
+	oldEntry, ok := pool.GetEntry(oldHash)
+	if !ok {
+		t.Fatal("old node should exist after initial refresh")
+	}
+	oldEntry.CircuitOpenSince.Store(time.Now().Add(-time.Minute).UnixNano())
+
+	newRaw := `{"type":"vmess","tag":"new-node","server":"2.2.2.2","server_port":443}`
+	sched.Fetcher = makeMockFetcher(makeSubscriptionJSON(newRaw), nil)
+	sched.UpdateSubscription(sub)
+
+	newHash := node.HashFromRawOptions([]byte(newRaw))
+	if _, ok := sub.ManagedNodes().LoadNode(oldHash); ok {
+		t.Fatal("unhealthy old node should be removed in incremental mode")
+	}
+	if _, ok := pool.GetEntry(oldHash); ok {
+		t.Fatal("unhealthy old node should be removed from pool")
+	}
+	if _, ok := sub.ManagedNodes().LoadNode(newHash); !ok {
+		t.Fatal("new node should still be present")
+	}
+}
+
 // --- Test: Rename triggers re-filter ---
 
 func TestScheduler_RenameSubscription(t *testing.T) {

--- a/internal/topology/subscription_scheduler.go
+++ b/internal/topology/subscription_scheduler.go
@@ -192,6 +192,7 @@ func (s *SubscriptionScheduler) runUpdatesWithWorkerLimit(subs []*subscription.S
 // (no I/O under lock) while still preventing concurrent diff/apply races.
 func (s *SubscriptionScheduler) UpdateSubscription(sub *subscription.Subscription) {
 	attemptStartedNs := time.Now().UnixNano()
+	attemptSeq := sub.NextAttemptSeq()
 	attemptURL := sub.URL()
 	attemptSourceType := sub.SourceType()
 	attemptContent := sub.Content()
@@ -207,7 +208,7 @@ func (s *SubscriptionScheduler) UpdateSubscription(sub *subscription.Subscriptio
 	} else {
 		body, err = s.Fetcher(attemptURL)
 		if err != nil {
-			s.handleUpdateFailure(sub, attemptStartedNs, attemptConfigVersion, "fetch", err)
+			s.handleUpdateFailure(sub, attemptStartedNs, attemptSeq, attemptConfigVersion, "fetch", err)
 			return
 		}
 	}
@@ -215,18 +216,18 @@ func (s *SubscriptionScheduler) UpdateSubscription(sub *subscription.Subscriptio
 	// 2. Parse (lock-free).
 	parsed, err := subscription.ParseGeneralSubscription(body)
 	if err != nil {
-		s.handleUpdateFailure(sub, attemptStartedNs, attemptConfigVersion, "parse", err)
+		s.handleUpdateFailure(sub, attemptStartedNs, attemptSeq, attemptConfigVersion, "parse", err)
 		return
 	}
 
-	// 3. Build new managed nodes map (lock-free, pure computation).
-	newManagedNodes := subscription.NewManagedNodes()
+	// 3. Build refreshed managed nodes map (lock-free, pure computation).
+	refreshedManagedNodes := subscription.NewManagedNodes()
 	rawByHash := make(map[node.Hash][]byte)
 	for _, p := range parsed {
 		h := node.HashFromRawOptions(p.RawOptions)
-		existing, _ := newManagedNodes.LoadNode(h)
+		existing, _ := refreshedManagedNodes.LoadNode(h)
 		existing.Tags = append(existing.Tags, p.Tag)
-		newManagedNodes.StoreNode(h, existing)
+		refreshedManagedNodes.StoreNode(h, existing)
 		if _, ok := rawByHash[h]; !ok {
 			rawByHash[h] = p.RawOptions
 		}
@@ -241,11 +242,29 @@ func (s *SubscriptionScheduler) UpdateSubscription(sub *subscription.Subscriptio
 		}
 		// Stale success guard: if a newer successful update has already landed,
 		// discard this older attempt to avoid rolling state backward.
-		if sub.LastUpdatedNs.Load() > attemptStartedNs {
+		if sub.LastAppliedSeq() > attemptSeq {
 			return
 		}
 
 		old := sub.ManagedNodes()
+		mergedManagedNodes := refreshedManagedNodes
+		if sub.IncrementalAliveNodes() {
+			mergedManagedNodes = subscription.NewManagedNodes()
+			old.RangeNodes(func(h node.Hash, oldNode subscription.ManagedNode) bool {
+				if oldNode.Evicted {
+					mergedManagedNodes.StoreNode(h, oldNode)
+					return true
+				}
+				if entry, ok := s.pool.GetEntry(h); ok && !shouldRemoveUnhealthyNodeForIncrementalMode(entry) {
+					mergedManagedNodes.StoreNode(h, oldNode)
+				}
+				return true
+			})
+			refreshedManagedNodes.RangeNodes(func(h node.Hash, refreshedNode subscription.ManagedNode) bool {
+				mergedManagedNodes.StoreNode(h, refreshedNode)
+				return true
+			})
+		}
 
 		// Keep hashes inherit historical eviction state so refresh will not
 		// re-add previously evicted nodes back into pool.
@@ -253,36 +272,58 @@ func (s *SubscriptionScheduler) UpdateSubscription(sub *subscription.Subscriptio
 			if !oldNode.Evicted {
 				return true
 			}
-			nextNode, ok := newManagedNodes.LoadNode(h)
+			nextNode, ok := mergedManagedNodes.LoadNode(h)
 			if !ok {
 				return true
 			}
 			nextNode.Evicted = true
-			newManagedNodes.StoreNode(h, nextNode)
+			mergedManagedNodes.StoreNode(h, nextNode)
 			return true
 		})
-		added, kept, removed := subscription.DiffHashes(old, newManagedNodes)
+		added, kept, removed := subscription.DiffHashes(old, mergedManagedNodes)
 
-		sub.SwapManagedNodes(newManagedNodes)
+		sub.SwapManagedNodes(mergedManagedNodes)
 
 		for _, h := range added {
-			s.pool.AddNodeFromSub(h, rawByHash[h], sub.ID)
-		}
-		for _, h := range kept {
-			managed, ok := newManagedNodes.LoadNode(h)
+			managed, ok := mergedManagedNodes.LoadNode(h)
 			if ok && managed.Evicted {
 				continue
 			}
-			s.pool.AddNodeFromSub(h, rawByHash[h], sub.ID)
+			raw := rawByHash[h]
+			if len(raw) == 0 {
+				if entry, ok := s.pool.GetEntry(h); ok {
+					raw = entry.RawOptions
+				}
+			}
+			if len(raw) == 0 {
+				continue
+			}
+			s.pool.AddNodeFromSub(h, raw, sub.ID)
+		}
+		for _, h := range kept {
+			managed, ok := mergedManagedNodes.LoadNode(h)
+			if ok && managed.Evicted {
+				continue
+			}
+			raw := rawByHash[h]
+			if len(raw) == 0 {
+				if entry, ok := s.pool.GetEntry(h); ok {
+					raw = entry.RawOptions
+				}
+			}
+			if len(raw) == 0 {
+				continue
+			}
+			s.pool.AddNodeFromSub(h, raw, sub.ID)
 		}
 		for _, h := range removed {
 			s.pool.RemoveNodeFromSub(h, sub.ID)
 		}
-
 		// 5. Update timestamps (inside lock, using current time).
 		now := time.Now().UnixNano()
 		sub.LastCheckedNs.Store(now)
 		sub.LastUpdatedNs.Store(now)
+		sub.MarkAppliedAttempt(attemptSeq)
 		sub.SetLastError("")
 		applied = true
 	})
@@ -299,9 +340,18 @@ func (s *SubscriptionScheduler) UpdateSubscription(sub *subscription.Subscriptio
 // handleUpdateFailure applies a fetch/parse failure to subscription state.
 // It ignores stale failures from an outdated attempt (config-version guard +
 // LastUpdatedNs stale-success guard).
+
+func shouldRemoveUnhealthyNodeForIncrementalMode(entry *node.NodeEntry) bool {
+	if entry == nil {
+		return false
+	}
+	return entry.IsCircuitOpen() || (!entry.HasOutbound() && entry.GetLastError() != "")
+}
+
 func (s *SubscriptionScheduler) handleUpdateFailure(
 	sub *subscription.Subscription,
 	attemptStartedNs int64,
+	attemptSeq int64,
 	attemptConfigVersion int64,
 	stage string,
 	err error,
@@ -312,7 +362,7 @@ func (s *SubscriptionScheduler) handleUpdateFailure(
 		if sub.ConfigVersion() != attemptConfigVersion {
 			return
 		}
-		if sub.LastUpdatedNs.Load() > attemptStartedNs {
+		if sub.LastAppliedSeq() > attemptSeq {
 			return
 		}
 		now := time.Now().UnixNano()

--- a/webui/src/features/subscriptions/SubscriptionPage.tsx
+++ b/webui/src/features/subscriptions/SubscriptionPage.tsx
@@ -47,6 +47,7 @@ const subscriptionCreateSchema = z.object({
   ephemeral_node_evict_delay: z.string().trim().min(1, "临时节点驱逐延迟不能为空"),
   enabled: z.boolean(),
   ephemeral: z.boolean(),
+  incremental_alive_nodes: z.boolean(),
 }).superRefine((value, ctx) => {
   const url = value.url.trim();
   const content = value.content.trim();
@@ -74,6 +75,7 @@ const PAGE_SIZE_OPTIONS = [10, 20, 50, 100] as const;
 const LOCAL_SOURCE_UPDATE_INTERVAL = "12h";
 const SUBSCRIPTION_DISABLE_HINT = "禁用订阅后，相关节点不会参与平台路由、健康统计或自动探测。";
 const SUBSCRIPTION_EPHEMERAL_HINT = "临时订阅的非健康节点会在一段时间后被自动删除。订阅本身不会被删除。";
+const SUBSCRIPTION_INCREMENTAL_HINT = "开启后刷新时保留当前仍存活的旧节点，仅清理失效旧节点，并合并新订阅内容；关闭后仅保留刷新后的订阅内容。";
 
 function extractHostname(url: string): string {
   try {
@@ -93,6 +95,7 @@ function subscriptionToEditForm(subscription: Subscription): SubscriptionEditFor
     ephemeral_node_evict_delay: subscription.ephemeral_node_evict_delay,
     enabled: subscription.enabled,
     ephemeral: subscription.ephemeral,
+    incremental_alive_nodes: subscription.incremental_alive_nodes,
   };
 }
 
@@ -183,6 +186,7 @@ export function SubscriptionPage() {
       ephemeral_node_evict_delay: "72h",
       enabled: true,
       ephemeral: false,
+      incremental_alive_nodes: false,
     },
   });
 
@@ -200,6 +204,7 @@ export function SubscriptionPage() {
       ephemeral_node_evict_delay: "72h",
       enabled: true,
       ephemeral: false,
+      incremental_alive_nodes: false,
     },
   });
 
@@ -254,6 +259,7 @@ export function SubscriptionPage() {
         ephemeral_node_evict_delay: "72h",
         enabled: true,
         ephemeral: false,
+        incremental_alive_nodes: false,
       });
       showToast("success", t("订阅 {{name}} 创建成功", { name: created.name }));
     },
@@ -274,6 +280,7 @@ export function SubscriptionPage() {
         ephemeral_node_evict_delay: formData.ephemeral_node_evict_delay.trim(),
         enabled: formData.enabled,
         ephemeral: formData.ephemeral,
+        incremental_alive_nodes: formData.incremental_alive_nodes,
         ...(formData.source_type === "remote"
           ? { url: formData.url.trim() }
           : { content: formData.content }),
@@ -374,6 +381,7 @@ export function SubscriptionPage() {
       ephemeral_node_evict_delay: values.ephemeral_node_evict_delay.trim(),
       enabled: values.enabled,
       ephemeral: values.ephemeral,
+      incremental_alive_nodes: values.incremental_alive_nodes,
       ...(values.source_type === "remote"
         ? { url: values.url.trim() }
         : { content: values.content }),
@@ -793,6 +801,26 @@ export function SubscriptionPage() {
                   </div>
 
                   <div className="field-group">
+                    <label className="field-label" htmlFor="edit-sub-incremental-alive-nodes" style={{ visibility: "hidden" }}>
+                      {t("存活节点增量模式")}
+                    </label>
+                    <div className="subscription-switch-item">
+                      <label className="subscription-switch-label" htmlFor="edit-sub-incremental-alive-nodes">
+                        <span>{t("存活节点增量模式")}</span>
+                        <span
+                          className="subscription-info-icon"
+                          title={t(SUBSCRIPTION_INCREMENTAL_HINT)}
+                          aria-label={t(SUBSCRIPTION_INCREMENTAL_HINT)}
+                          tabIndex={0}
+                        >
+                          <Info size={13} />
+                        </span>
+                      </label>
+                      <Switch id="edit-sub-incremental-alive-nodes" {...editForm.register("incremental_alive_nodes")} />
+                    </div>
+                  </div>
+
+                  <div className="field-group">
                     <label className="field-label" htmlFor="edit-sub-ephemeral-evict-delay">
                       {t("临时节点驱逐延迟")}
                     </label>
@@ -1000,6 +1028,26 @@ export function SubscriptionPage() {
                     </span>
                   </label>
                   <Switch id="create-sub-ephemeral" {...createForm.register("ephemeral")} />
+                </div>
+              </div>
+
+              <div className="field-group">
+                <label className="field-label" htmlFor="create-sub-incremental-alive-nodes" style={{ visibility: "hidden" }}>
+                  {t("存活节点增量模式")}
+                </label>
+                <div className="subscription-switch-item">
+                  <label className="subscription-switch-label" htmlFor="create-sub-incremental-alive-nodes">
+                    <span>{t("存活节点增量模式")}</span>
+                    <span
+                      className="subscription-info-icon"
+                      title={t(SUBSCRIPTION_INCREMENTAL_HINT)}
+                      aria-label={t(SUBSCRIPTION_INCREMENTAL_HINT)}
+                      tabIndex={0}
+                    >
+                      <Info size={13} />
+                    </span>
+                  </label>
+                  <Switch id="create-sub-incremental-alive-nodes" {...createForm.register("incremental_alive_nodes")} />
                 </div>
               </div>
 

--- a/webui/src/features/subscriptions/SubscriptionPage.tsx
+++ b/webui/src/features/subscriptions/SubscriptionPage.tsx
@@ -836,19 +836,24 @@ export function SubscriptionPage() {
                     ) : null}
                   </div>
 
-                  <div className="subscription-switch-item">
-                    <label className="subscription-switch-label" htmlFor="edit-sub-enabled">
-                      <span>{t("启用")}</span>
-                      <span
-                        className="subscription-info-icon"
-                        title={t(SUBSCRIPTION_DISABLE_HINT)}
-                        aria-label={t(SUBSCRIPTION_DISABLE_HINT)}
-                        tabIndex={0}
-                      >
-                        <Info size={13} />
-                      </span>
+                  <div className="field-group">
+                    <label className="field-label" htmlFor="edit-sub-enabled" style={{ visibility: "hidden" }}>
+                      {t("启用")}
                     </label>
-                    <Switch id="edit-sub-enabled" {...editForm.register("enabled")} />
+                    <div className="subscription-switch-item">
+                      <label className="subscription-switch-label" htmlFor="edit-sub-enabled">
+                        <span>{t("启用")}</span>
+                        <span
+                          className="subscription-info-icon"
+                          title={t(SUBSCRIPTION_DISABLE_HINT)}
+                          aria-label={t(SUBSCRIPTION_DISABLE_HINT)}
+                          tabIndex={0}
+                        >
+                          <Info size={13} />
+                        </span>
+                      </label>
+                      <Switch id="edit-sub-enabled" {...editForm.register("enabled")} />
+                    </div>
                   </div>
 
                   <div className="platform-config-actions">
@@ -1067,19 +1072,24 @@ export function SubscriptionPage() {
                 ) : null}
               </div>
 
-              <div className="subscription-switch-item">
-                <label className="subscription-switch-label" htmlFor="create-sub-enabled">
-                  <span>{t("启用")}</span>
-                  <span
-                    className="subscription-info-icon"
-                    title={t(SUBSCRIPTION_DISABLE_HINT)}
-                    aria-label={t(SUBSCRIPTION_DISABLE_HINT)}
-                    tabIndex={0}
-                  >
-                    <Info size={13} />
-                  </span>
+              <div className="field-group">
+                <label className="field-label" htmlFor="create-sub-enabled" style={{ visibility: "hidden" }}>
+                  {t("启用")}
                 </label>
-                <Switch id="create-sub-enabled" {...createForm.register("enabled")} />
+                <div className="subscription-switch-item">
+                  <label className="subscription-switch-label" htmlFor="create-sub-enabled">
+                    <span>{t("启用")}</span>
+                    <span
+                      className="subscription-info-icon"
+                      title={t(SUBSCRIPTION_DISABLE_HINT)}
+                      aria-label={t(SUBSCRIPTION_DISABLE_HINT)}
+                      tabIndex={0}
+                    >
+                      <Info size={13} />
+                    </span>
+                  </label>
+                  <Switch id="create-sub-enabled" {...createForm.register("enabled")} />
+                </div>
               </div>
 
               <div className="detail-actions" style={{ justifyContent: "flex-end" }}>

--- a/webui/src/features/subscriptions/types.ts
+++ b/webui/src/features/subscriptions/types.ts
@@ -8,6 +8,7 @@ export type Subscription = {
   node_count: number;
   healthy_node_count: number;
   ephemeral: boolean;
+  incremental_alive_nodes: boolean;
   ephemeral_node_evict_delay: string;
   enabled: boolean;
   created_at: string;
@@ -31,6 +32,7 @@ export type SubscriptionCreateInput = {
   update_interval?: string;
   enabled?: boolean;
   ephemeral?: boolean;
+  incremental_alive_nodes?: boolean;
   ephemeral_node_evict_delay?: string;
 };
 
@@ -41,5 +43,6 @@ export type SubscriptionUpdateInput = {
   update_interval?: string;
   enabled?: boolean;
   ephemeral?: boolean;
+  incremental_alive_nodes?: boolean;
   ephemeral_node_evict_delay?: string;
 };

--- a/webui/src/i18n/translations.ts
+++ b/webui/src/i18n/translations.ts
@@ -514,6 +514,9 @@ const EXACT_ZH_TO_EN: Record<string, string> = {
     "After disabling a subscription, related nodes will not participate in platform routing, health statistics, or automatic probing.",
   "临时订阅的非健康节点会在一段时间后被自动删除。订阅本身不会被删除。":
     "Unhealthy nodes in temporary subscriptions will be auto-removed after a delay. The subscription itself will not be deleted.",
+  "存活节点增量模式": "Incremental Alive Nodes",
+  "开启后刷新时保留当前仍存活的旧节点，仅清理失效旧节点，并合并新订阅内容；关闭后仅保留刷新后的订阅内容。":
+    "When enabled, refresh keeps existing old nodes that are still alive, removes only stale old nodes, and merges the new subscription content. When disabled, only the refreshed subscription content is kept.",
   "开始测试": "Start test",
   "例如 12h": "e.g. 12h",
   "例如 168h": "e.g. 168h",


### PR DESCRIPTION
背景

当前订阅刷新默认采用全量替换模式：每次刷新后，仅保留本次订阅返回的节点。

但在实际使用中，订阅源可能会出现短暂波动、返回不完整内容，或者节点会在不同刷新周期中频繁进出。对于这类场景，如果每次都直接全量替换，可能会把当前仍然可用的旧节点一并移除，导致节点池波动过大，影响可用性。

本次改动为订阅增加“存活节点增量模式”开关。开启后，刷新订阅时会保留当前仍存活的旧节点，仅清理失效旧节点，并合并新的订阅内容。

改动

将订阅新增 `incremental_alive_nodes` 开关，并打通完整链路：

- 数据模型新增 `incremental_alive_nodes` 字段
- `subscriptions` 表新增 `incremental_alive_nodes` 列，默认值为 `0`
- 启动加载订阅时，将该字段从 `state.db` 恢复到运行时订阅对象
- 控制面订阅接口新增/透出 `incremental_alive_nodes`
  - 创建订阅支持传入
  - 查询订阅支持返回
  - PATCH 更新订阅支持修改
- Web UI 订阅页面新增“存活节点增量模式”开关
  - 创建订阅时可配置
  - 编辑订阅时可修改
  - 补充对应说明文案

调整订阅调度器刷新逻辑：

- 关闭开关时，维持原有全量替换行为
- 开启开关时：
  - 保留当前仍健康、仍可继续使用的旧节点
  - 合并本次刷新得到的新节点
  - 清理已熔断、无 outbound 且已有错误状态的旧节点
  - 保留历史驱逐状态，避免已驱逐节点在刷新后被重新加入

补强调度器并发刷新保护：

- 为刷新尝试增加递增序号
- 使用 `attemptSeq` / `lastAppliedSeq` 防止旧刷新结果覆盖新刷新结果
- 失败路径同样增加过期保护，避免旧错误状态覆盖当前状态

测试补充

本 PR 同步补充了相关测试用例，覆盖：

- API 创建订阅时传入 `incremental_alive_nodes`
- API 查询订阅时返回 `incremental_alive_nodes`
- 调度器在增量模式下保留健康旧节点
- 调度器在增量模式下清理不健康旧节点
- 已驱逐节点不会因后续刷新重新加入节点池

验证

已检查：

- 订阅模型、状态库、控制面服务、调度器、前端订阅页已完整接入 `incremental_alive_nodes`
- 状态迁移已新增 `000005_subscriptions_add_incremental_alive_nodes`
- 调度器刷新逻辑已区分“全量替换”与“存活节点增量模式”

本地执行：

- `go test ./...`

当前仓库测试未全量通过，失败项包括：

- `webui/embed.go` 依赖 `dist` 目录，当前缺失导致部分包 setup failed
- `internal/proxy` 存在连接重置相关失败用例
- `internal/routing` 存在 lease 过期时间相关失败用例
- `internal/state` 存在 legacy state migration 相关失败用例

因此本次改动的验证重点主要放在代码链路、迁移文件和新增测试覆盖范围上；全量测试问题需结合仓库当前基线继续排查。

关联说明

本次改动主要解决“订阅刷新只能全量替换、无法保留存活旧节点”的问题，为后续在订阅波动场景下控制节点保留策略提供基础能力。

关闭开关时维持原有行为；
开启后则切换为“保留存活旧节点 + 合并新节点”的刷新模式。