### PR TITLE
feat: add platform proxy URL copy panel (closes #26)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ sing-box-reference
 .agents
 .devcontainer
 start-instance.sh
+
+# Claude Code / OMC tooling and local runtime data
+.claude/
+.omc/
+.local/

--- a/internal/api/handler_system.go
+++ b/internal/api/handler_system.go
@@ -50,6 +50,7 @@ type systemEnvConfigResponse struct {
 	ProxyTokenSet                                   bool            `json:"proxy_token_set"`
 	AdminTokenWeak                                  bool            `json:"admin_token_weak"`
 	ProxyTokenWeak                                  bool            `json:"proxy_token_weak"`
+	AuthVersion                                     string          `json:"auth_version"`
 }
 
 // HandleSystemInfo returns a handler for GET /api/v1/system/info.
@@ -148,5 +149,6 @@ func systemEnvConfigSnapshot(envCfg *config.EnvConfig) *systemEnvConfigResponse 
 		ProxyTokenSet:                                   proxyTokenSet,
 		AdminTokenWeak:                                  adminTokenSet && config.IsWeakToken(envCfg.AdminToken),
 		ProxyTokenWeak:                                  proxyTokenSet && config.IsWeakToken(envCfg.ProxyToken),
+		AuthVersion:                                     string(envCfg.AuthVersion),
 	}
 }

--- a/webui/src/features/platforms/PlatformAccessPanel.tsx
+++ b/webui/src/features/platforms/PlatformAccessPanel.tsx
@@ -1,7 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { Check, Copy, Info } from "lucide-react";
 import { useMemo, useState } from "react";
-import { Badge } from "../../components/ui/Badge";
 import { Button } from "../../components/ui/Button";
 import { Input } from "../../components/ui/Input";
 import { useI18n } from "../../i18n";
@@ -9,6 +8,8 @@ import { getEnvConfig } from "../systemConfig/api";
 
 const PROXY_TOKEN_STORAGE_KEY = "resin_proxy_token";
 const TOKEN_PLACEHOLDER = "<token>";
+
+type ProxyEndpoint = { scheme: string; host: string };
 
 function loadStoredProxyToken(): string {
   if (typeof window === "undefined") {
@@ -28,14 +29,49 @@ function persistProxyToken(value: string): void {
   }
 }
 
-function currentHost(fallbackPort: number): string {
+function formatHostWithPort(hostname: string, port: number): string {
+  const host = hostname.includes(":") && !hostname.startsWith("[") ? `[${hostname}]` : hostname;
+  return port ? `${host}:${port}` : host;
+}
+
+function configuredApiEndpoint(): ProxyEndpoint | null {
+  const apiBase = import.meta.env.VITE_API_BASE_URL?.trim();
+  if (!apiBase || !/^https?:\/\//i.test(apiBase)) {
+    return null;
+  }
+  try {
+    const url = new URL(apiBase);
+    return { scheme: url.protocol.replace(/:$/, ""), host: url.host };
+  } catch {
+    return null;
+  }
+}
+
+function currentProxyEndpoint(fallbackPort: number): ProxyEndpoint {
+  const configured = configuredApiEndpoint();
+  if (configured) {
+    return configured;
+  }
+
   if (typeof window === "undefined") {
-    return fallbackPort ? `127.0.0.1:${fallbackPort}` : "127.0.0.1:2260";
+    return { scheme: "http", host: fallbackPort ? `127.0.0.1:${fallbackPort}` : "127.0.0.1:2260" };
+  }
+
+  const scheme = currentScheme();
+  const expectedPort = fallbackPort || 2260;
+  const currentPort = Number(window.location.port);
+  if (import.meta.env.DEV && window.location.hostname && currentPort && currentPort !== expectedPort) {
+    return { scheme, host: formatHostWithPort(window.location.hostname, expectedPort) };
   }
   if (window.location.host) {
-    return window.location.host;
+    return { scheme, host: window.location.host };
   }
-  return fallbackPort ? `${window.location.hostname}:${fallbackPort}` : window.location.hostname;
+  return {
+    scheme,
+    host: window.location.hostname
+      ? formatHostWithPort(window.location.hostname, expectedPort)
+      : `127.0.0.1:${expectedPort}`,
+  };
 }
 
 function currentScheme(): string {
@@ -49,6 +85,10 @@ function currentScheme(): string {
 // placeholder readable so users can see where to paste the real token.
 function encodeSegment(value: string): string {
   return value === TOKEN_PLACEHOLDER ? value : encodeURIComponent(value);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 type ParsedTarget = { protocol: string; rest: string };
@@ -148,8 +188,9 @@ export function PlatformAccessPanel({ platformName }: PlatformAccessPanelProps) 
   const env = envQuery.data;
   const proxyTokenSet = env?.proxy_token_set ?? true;
   const isLegacy = env?.auth_version === "LEGACY_V0";
-  const host = currentHost(env?.resin_port ?? 2260);
-  const scheme = currentScheme();
+  const endpoint = currentProxyEndpoint(env?.resin_port ?? 2260);
+  const host = endpoint.host;
+  const scheme = endpoint.scheme;
 
   const handleTokenChange = (value: string) => {
     setToken(value);
@@ -159,7 +200,7 @@ export function PlatformAccessPanel({ platformName }: PlatformAccessPanelProps) 
   const urls = useMemo(() => {
     const platform = platformName.trim() || "Default";
     const acc = account.trim();
-    const tokenRaw = token.trim();
+    const tokenRaw = proxyTokenSet ? token.trim() : "";
     const sep = isLegacy ? ":" : ".";
 
     // Raw identity/credential are used verbatim for the curl -U value.
@@ -168,6 +209,9 @@ export function PlatformAccessPanel({ platformName }: PlatformAccessPanelProps) 
     const identityEnc = acc
       ? `${encodeSegment(platform)}${sep}${encodeSegment(acc)}`
       : encodeSegment(platform);
+    const reverseIdentityEnc = isLegacy
+      ? `${encodeSegment(platform)}:${acc ? encodeSegment(acc) : ""}`
+      : identityEnc;
 
     // forward token: literal placeholder only when auth is enabled but unset.
     const forwardToken = tokenRaw || (proxyTokenSet ? TOKEN_PLACEHOLDER : "");
@@ -185,14 +229,21 @@ export function PlatformAccessPanel({ platformName }: PlatformAccessPanelProps) 
     const httpForward = `http://${userInfo}@${host}`;
     const socksForward = `socks5h://${userInfo}@${host}`;
 
-    const reverseTokenSeg = encodeSegment(tokenRaw || TOKEN_PLACEHOLDER);
+    const reverseTokenSeg = proxyTokenSet ? encodeSegment(tokenRaw || TOKEN_PLACEHOLDER) : "";
     const parsed = parseTarget(target);
     const reverseUrl = parsed
-      ? `${scheme}://${host}/${reverseTokenSeg}/${identityEnc}/${parsed.protocol}/${parsed.rest}`
+      ? `${scheme}://${host}/${reverseTokenSeg}/${reverseIdentityEnc}/${parsed.protocol}/${parsed.rest}`
       : "";
 
-    const curlForward = `curl -x http://${host} -U "${forwardCredential}" https://api.ipify.org`;
-    const curlReverse = reverseUrl ? `curl "${reverseUrl}"` : "";
+    const curlForward = [
+      "curl",
+      "-x",
+      shellQuote(`http://${host}`),
+      "-U",
+      shellQuote(forwardCredential),
+      shellQuote("https://api.ipify.org"),
+    ].join(" ");
+    const curlReverse = reverseUrl ? `curl ${shellQuote(reverseUrl)}` : "";
 
     return { httpForward, socksForward, reverseUrl, curlForward, curlReverse };
   }, [platformName, account, token, isLegacy, proxyTokenSet, host, scheme, target]);
@@ -200,6 +251,7 @@ export function PlatformAccessPanel({ platformName }: PlatformAccessPanelProps) 
   const copyLabel = t("复制");
   const copiedLabel = t("已复制");
   const tokenMissing = proxyTokenSet && !token.trim();
+  const tokenInputValue = proxyTokenSet ? token : "";
 
   return (
     <section className="platform-detail-tabpanel platform-access-section">
@@ -236,9 +288,14 @@ export function PlatformAccessPanel({ platformName }: PlatformAccessPanelProps) 
           <Input
             id="access-token"
             type="password"
-            placeholder={proxyTokenSet ? t("填写 RESIN_PROXY_TOKEN") : t("当前代理免认证，可留空")}
-            value={token}
-            onChange={(event) => handleTokenChange(event.target.value)}
+            placeholder={proxyTokenSet ? t("填写 RESIN_PROXY_TOKEN") : t("当前代理免认证，无需填写")}
+            value={tokenInputValue}
+            onChange={(event) => {
+              if (proxyTokenSet) {
+                handleTokenChange(event.target.value);
+              }
+            }}
+            disabled={!proxyTokenSet}
             autoComplete="off"
           />
           {tokenMissing ? (
@@ -248,13 +305,6 @@ export function PlatformAccessPanel({ platformName }: PlatformAccessPanelProps) 
           ) : null}
         </div>
       </div>
-
-      {!proxyTokenSet ? (
-        <div className="platform-access-note">
-          <Badge variant="warning">{t("代理免认证")}</Badge>
-          <span>{t("后端 RESIN_PROXY_TOKEN 为空，正/反向代理无需认证。")}</span>
-        </div>
-      ) : null}
 
       <div className="platform-access-group">
         <h5>{t("正向代理")}</h5>

--- a/webui/src/features/platforms/PlatformAccessPanel.tsx
+++ b/webui/src/features/platforms/PlatformAccessPanel.tsx
@@ -1,0 +1,323 @@
+import { useQuery } from "@tanstack/react-query";
+import { Check, Copy, Info } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Badge } from "../../components/ui/Badge";
+import { Button } from "../../components/ui/Button";
+import { Input } from "../../components/ui/Input";
+import { useI18n } from "../../i18n";
+import { getEnvConfig } from "../systemConfig/api";
+
+const PROXY_TOKEN_STORAGE_KEY = "resin_proxy_token";
+const TOKEN_PLACEHOLDER = "<token>";
+
+function loadStoredProxyToken(): string {
+  if (typeof window === "undefined") {
+    return "";
+  }
+  return window.localStorage.getItem(PROXY_TOKEN_STORAGE_KEY) ?? "";
+}
+
+function persistProxyToken(value: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  if (value) {
+    window.localStorage.setItem(PROXY_TOKEN_STORAGE_KEY, value);
+  } else {
+    window.localStorage.removeItem(PROXY_TOKEN_STORAGE_KEY);
+  }
+}
+
+function currentHost(fallbackPort: number): string {
+  if (typeof window === "undefined") {
+    return fallbackPort ? `127.0.0.1:${fallbackPort}` : "127.0.0.1:2260";
+  }
+  if (window.location.host) {
+    return window.location.host;
+  }
+  return fallbackPort ? `${window.location.hostname}:${fallbackPort}` : window.location.hostname;
+}
+
+function currentScheme(): string {
+  if (typeof window === "undefined" || !window.location.protocol) {
+    return "http";
+  }
+  return window.location.protocol.replace(/:$/, "");
+}
+
+// Encode a URL segment/userinfo component, but keep the literal <token>
+// placeholder readable so users can see where to paste the real token.
+function encodeSegment(value: string): string {
+  return value === TOKEN_PLACEHOLDER ? value : encodeURIComponent(value);
+}
+
+type ParsedTarget = { protocol: string; rest: string };
+
+function parseTarget(raw: string): ParsedTarget | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const withScheme = /^[a-zA-Z][\w+.-]*:\/\//.test(trimmed) ? trimmed : `https://${trimmed}`;
+  let url: URL;
+  try {
+    url = new URL(withScheme);
+  } catch {
+    return null;
+  }
+  const protocol = url.protocol.replace(/:$/, "").toLowerCase();
+  if (protocol !== "http" && protocol !== "https") {
+    return null;
+  }
+  const path = url.pathname === "/" ? "" : url.pathname;
+  return { protocol, rest: `${url.host}${path}${url.search}` };
+}
+
+type CopyFieldProps = {
+  label: string;
+  value: string;
+  hint?: string;
+  copyLabel: string;
+  copiedLabel: string;
+};
+
+function CopyField({ label, value, hint, copyLabel, copiedLabel }: CopyFieldProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(value);
+      } else {
+        const area = document.createElement("textarea");
+        area.value = value;
+        area.style.position = "fixed";
+        area.style.opacity = "0";
+        document.body.appendChild(area);
+        area.select();
+        document.execCommand("copy");
+        document.body.removeChild(area);
+      }
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <div className="platform-access-field">
+      <div className="platform-access-field-head">
+        <span className="platform-access-field-label">{label}</span>
+        {hint ? <span className="platform-access-field-hint">{hint}</span> : null}
+      </div>
+      <div className="platform-access-field-body">
+        <code className="platform-access-value" title={value}>
+          {value}
+        </code>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => void handleCopy()}
+          className="platform-access-copy-btn"
+        >
+          {copied ? <Check size={14} /> : <Copy size={14} />}
+          {copied ? copiedLabel : copyLabel}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+type PlatformAccessPanelProps = {
+  platformName: string;
+};
+
+export function PlatformAccessPanel({ platformName }: PlatformAccessPanelProps) {
+  const { t } = useI18n();
+  const [account, setAccount] = useState("");
+  const [token, setToken] = useState(loadStoredProxyToken);
+  const [target, setTarget] = useState("https://api.ipify.org");
+
+  const envQuery = useQuery({
+    queryKey: ["system-env-config"],
+    queryFn: getEnvConfig,
+    staleTime: 60_000,
+  });
+
+  const env = envQuery.data;
+  const proxyTokenSet = env?.proxy_token_set ?? true;
+  const isLegacy = env?.auth_version === "LEGACY_V0";
+  const host = currentHost(env?.resin_port ?? 2260);
+  const scheme = currentScheme();
+
+  const handleTokenChange = (value: string) => {
+    setToken(value);
+    persistProxyToken(value.trim());
+  };
+
+  const urls = useMemo(() => {
+    const platform = platformName.trim() || "Default";
+    const acc = account.trim();
+    const tokenRaw = token.trim();
+    const sep = isLegacy ? ":" : ".";
+
+    // Raw identity/credential are used verbatim for the curl -U value.
+    const identityRaw = acc ? `${platform}${sep}${acc}` : platform;
+    // Encoded identity is reused for URL userinfo and reverse path segment.
+    const identityEnc = acc
+      ? `${encodeSegment(platform)}${sep}${encodeSegment(acc)}`
+      : encodeSegment(platform);
+
+    // forward token: literal placeholder only when auth is enabled but unset.
+    const forwardToken = tokenRaw || (proxyTokenSet ? TOKEN_PLACEHOLDER : "");
+
+    let forwardCredential: string;
+    let userInfo: string;
+    if (isLegacy) {
+      forwardCredential = forwardToken ? `${forwardToken}:${identityRaw}` : identityRaw;
+      userInfo = forwardToken ? `${encodeSegment(forwardToken)}:${identityEnc}` : identityEnc;
+    } else {
+      forwardCredential = forwardToken ? `${identityRaw}:${forwardToken}` : identityRaw;
+      userInfo = forwardToken ? `${identityEnc}:${encodeSegment(forwardToken)}` : identityEnc;
+    }
+
+    const httpForward = `http://${userInfo}@${host}`;
+    const socksForward = `socks5h://${userInfo}@${host}`;
+
+    const reverseTokenSeg = encodeSegment(tokenRaw || TOKEN_PLACEHOLDER);
+    const parsed = parseTarget(target);
+    const reverseUrl = parsed
+      ? `${scheme}://${host}/${reverseTokenSeg}/${identityEnc}/${parsed.protocol}/${parsed.rest}`
+      : "";
+
+    const curlForward = `curl -x http://${host} -U "${forwardCredential}" https://api.ipify.org`;
+    const curlReverse = reverseUrl ? `curl "${reverseUrl}"` : "";
+
+    return { httpForward, socksForward, reverseUrl, curlForward, curlReverse };
+  }, [platformName, account, token, isLegacy, proxyTokenSet, host, scheme, target]);
+
+  const copyLabel = t("复制");
+  const copiedLabel = t("已复制");
+  const tokenMissing = proxyTokenSet && !token.trim();
+
+  return (
+    <section className="platform-detail-tabpanel platform-access-section">
+      <div className="platform-drawer-section-head">
+        <h4>{t("接入方式")}</h4>
+        <p>{t("填写账号与代理 token，一键复制正向/反向代理地址。")}</p>
+      </div>
+
+      <div className="platform-access-inputs">
+        <div className="field-group">
+          <label className="field-label" htmlFor="access-account">
+            {t("业务账号（可选）")}
+          </label>
+          <Input
+            id="access-account"
+            placeholder={t("例如 user_tom，留空则只按平台路由")}
+            value={account}
+            onChange={(event) => setAccount(event.target.value)}
+          />
+        </div>
+
+        <div className="field-group">
+          <label className="field-label field-label-with-info" htmlFor="access-token">
+            <span>{t("代理 token")}</span>
+            <span
+              className="subscription-info-icon"
+              title={t("即后端 RESIN_PROXY_TOKEN。仅保存在浏览器本地，不会上传服务器。")}
+              aria-label={t("即后端 RESIN_PROXY_TOKEN。仅保存在浏览器本地，不会上传服务器。")}
+              tabIndex={0}
+            >
+              <Info size={13} />
+            </span>
+          </label>
+          <Input
+            id="access-token"
+            type="password"
+            placeholder={proxyTokenSet ? t("填写 RESIN_PROXY_TOKEN") : t("当前代理免认证，可留空")}
+            value={token}
+            onChange={(event) => handleTokenChange(event.target.value)}
+            autoComplete="off"
+          />
+          {tokenMissing ? (
+            <p className="muted" style={{ marginTop: 4, fontSize: 12 }}>
+              {t("尚未填写 token，地址中将以 <token> 占位，请替换为实际值。")}
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      {!proxyTokenSet ? (
+        <div className="platform-access-note">
+          <Badge variant="warning">{t("代理免认证")}</Badge>
+          <span>{t("后端 RESIN_PROXY_TOKEN 为空，正/反向代理无需认证。")}</span>
+        </div>
+      ) : null}
+
+      <div className="platform-access-group">
+        <h5>{t("正向代理")}</h5>
+        <CopyField
+          label={t("HTTP 正向代理")}
+          value={urls.httpForward}
+          copyLabel={copyLabel}
+          copiedLabel={copiedLabel}
+        />
+        {isLegacy ? (
+          <p className="muted" style={{ fontSize: 12 }}>
+            {t("当前为 LEGACY_V0 鉴权，SOCKS5 正向代理未启用。")}
+          </p>
+        ) : (
+          <CopyField
+            label={t("SOCKS5 正向代理")}
+            value={urls.socksForward}
+            copyLabel={copyLabel}
+            copiedLabel={copiedLabel}
+          />
+        )}
+        <CopyField
+          label={t("curl 示例")}
+          value={urls.curlForward}
+          copyLabel={copyLabel}
+          copiedLabel={copiedLabel}
+        />
+      </div>
+
+      <div className="platform-access-group">
+        <h5>{t("反向代理")}</h5>
+        <div className="field-group">
+          <label className="field-label" htmlFor="access-target">
+            {t("目标网址")}
+          </label>
+          <Input
+            id="access-target"
+            placeholder={t("例如 https://api.ipify.org")}
+            value={target}
+            onChange={(event) => setTarget(event.target.value)}
+          />
+        </div>
+        {urls.reverseUrl ? (
+          <>
+            <CopyField
+              label={t("反向代理地址")}
+              value={urls.reverseUrl}
+              copyLabel={copyLabel}
+              copiedLabel={copiedLabel}
+            />
+            <CopyField
+              label={t("curl 示例")}
+              value={urls.curlReverse}
+              copyLabel={copyLabel}
+              copiedLabel={copiedLabel}
+            />
+          </>
+        ) : (
+          <p className="muted" style={{ fontSize: 12 }}>
+            {t("请输入合法的 http/https 目标网址以生成反向代理地址。")}
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/webui/src/features/platforms/PlatformDetailPage.tsx
+++ b/webui/src/features/platforms/PlatformDetailPage.tsx
@@ -33,13 +33,15 @@ import {
   toPlatformUpdateInput,
   type PlatformFormValues,
 } from "./formModel";
+import { PlatformAccessPanel } from "./PlatformAccessPanel";
 import { PlatformMonitorPanel } from "./PlatformMonitorPanel";
 
-type PlatformDetailTab = "monitor" | "config" | "ops";
+type PlatformDetailTab = "monitor" | "access" | "config" | "ops";
 
 const ZERO_UUID = "00000000-0000-0000-0000-000000000000";
 const DETAIL_TABS: Array<{ key: PlatformDetailTab; label: string; hint: string }> = [
   { key: "monitor", label: "监控", hint: "平台运行态趋势和快照" },
+  { key: "access", label: "接入", hint: "复制正向/反向代理地址" },
   { key: "config", label: "配置", hint: "过滤规则与分配策略" },
   { key: "ops", label: "运维", hint: "重置、清租约、删除操作" },
 ];
@@ -313,6 +315,17 @@ export function PlatformDetailPage() {
                 className="platform-detail-panel"
               >
                 <PlatformMonitorPanel platform={platform} />
+              </div>
+            ) : null}
+
+            {activeTab === "access" ? (
+              <div
+                id="platform-tabpanel-access"
+                role="tabpanel"
+                aria-labelledby="platform-tab-access"
+                className="platform-detail-panel"
+              >
+                <PlatformAccessPanel platformName={platform.name} />
               </div>
             ) : null}
 

--- a/webui/src/features/systemConfig/types.ts
+++ b/webui/src/features/systemConfig/types.ts
@@ -59,6 +59,7 @@ export type EnvConfig = {
   proxy_token_set: boolean;
   admin_token_weak: boolean;
   proxy_token_weak: boolean;
+  auth_version: string;
 };
 
 export type RuntimeConfigPatch = Partial<RuntimeConfig>;

--- a/webui/src/i18n/translations.ts
+++ b/webui/src/i18n/translations.ts
@@ -267,6 +267,7 @@ const EXACT_ZH_TO_EN: Record<string, string> = {
     "This is the backend RESIN_PROXY_TOKEN. Stored only in your browser, never uploaded.",
   "填写 RESIN_PROXY_TOKEN": "Enter RESIN_PROXY_TOKEN",
   "当前代理免认证，可留空": "Proxy is unauthenticated; can be left empty",
+  "当前代理免认证，无需填写": "Proxy is unauthenticated; no token required",
   "尚未填写 token，地址中将以 <token> 占位，请替换为实际值。":
     "Token not set; URLs use <token> as a placeholder — replace it with the real value.",
   "代理免认证": "No-auth proxy",

--- a/webui/src/i18n/translations.ts
+++ b/webui/src/i18n/translations.ts
@@ -255,6 +255,33 @@ const EXACT_ZH_TO_EN: Record<string, string> = {
   "正向代理": "Forward Proxy",
   "反向代理": "Reverse Proxy",
   "SOCKS5 正向代理": "SOCKS5 Forward Proxy",
+  "接入": "Access",
+  "复制正向/反向代理地址": "Copy forward / reverse proxy URLs",
+  "接入方式": "Access",
+  "填写账号与代理 token，一键复制正向/反向代理地址。":
+    "Fill in the account and proxy token to copy forward / reverse proxy URLs with one click.",
+  "业务账号（可选）": "Business account (optional)",
+  "例如 user_tom，留空则只按平台路由": "e.g. user_tom; leave empty to route by platform only",
+  "代理 token": "Proxy token",
+  "即后端 RESIN_PROXY_TOKEN。仅保存在浏览器本地，不会上传服务器。":
+    "This is the backend RESIN_PROXY_TOKEN. Stored only in your browser, never uploaded.",
+  "填写 RESIN_PROXY_TOKEN": "Enter RESIN_PROXY_TOKEN",
+  "当前代理免认证，可留空": "Proxy is unauthenticated; can be left empty",
+  "尚未填写 token，地址中将以 <token> 占位，请替换为实际值。":
+    "Token not set; URLs use <token> as a placeholder — replace it with the real value.",
+  "代理免认证": "No-auth proxy",
+  "后端 RESIN_PROXY_TOKEN 为空，正/反向代理无需认证。":
+    "Backend RESIN_PROXY_TOKEN is empty; forward/reverse proxy require no authentication.",
+  "当前为 LEGACY_V0 鉴权，SOCKS5 正向代理未启用。":
+    "LEGACY_V0 auth is active; SOCKS5 forward proxy is not enabled.",
+  "curl 示例": "curl example",
+  "目标网址": "Target URL",
+  "例如 https://api.ipify.org": "e.g. https://api.ipify.org",
+  "反向代理地址": "Reverse Proxy URL",
+  "请输入合法的 http/https 目标网址以生成反向代理地址。":
+    "Enter a valid http/https target URL to generate the reverse proxy URL.",
+  "复制": "Copy",
+  "已复制": "Copied",
   "HTTP": "HTTP",
   "随机选择节点": "Select node randomly",
   "按空账号处理": "Treat as empty account",

--- a/webui/src/styles/theme.css
+++ b/webui/src/styles/theme.css
@@ -786,6 +786,101 @@ a {
   padding: 0;
 }
 
+.platform-access-section {
+  gap: 16px;
+}
+
+.platform-access-inputs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.platform-access-note {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.platform-access-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+}
+
+.platform-access-group h5 {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text);
+}
+
+.platform-access-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.platform-access-field-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.platform-access-field-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.platform-access-field-hint {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.platform-access-field-body {
+  display: flex;
+  align-items: stretch;
+  gap: 8px;
+}
+
+.platform-access-value {
+  flex: 1;
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface-strong);
+  color: var(--text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.platform-access-copy-btn {
+  flex-shrink: 0;
+  gap: 4px;
+}
+
+@media (max-width: 640px) {
+  .platform-access-field-body {
+    flex-direction: column;
+  }
+
+  .platform-access-value {
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+}
+
 .nodes-page {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
Implements the convenience feature requested in #26: copy forward/reverse proxy URLs directly from each platform.

Adds an **「接入」(Access)** tab to the platform detail page that generates copyable connection strings for the current platform:
- **HTTP forward proxy**: `http://Platform.Account:token@host:port`
- **SOCKS5 forward proxy**: `socks5h://Platform.Account:token@host:port` (V1 only)
- **Reverse proxy generator**: enter a target URL → `http://host:port/token/Platform.Account/protocol/target`
- **curl examples** for both forward and reverse modes

Details:
- Business account and proxy token are entered locally; the token is kept in `localStorage` and **never uploaded** (the backend already does not expose `RESIN_PROXY_TOKEN`).
- Exposes `auth_version` via `GET /api/v1/system/config/env` so generated URLs match the active auth scheme (V1 uses `.` separator; LEGACY_V0 uses `:` and hides SOCKS5).
- Handles the no-auth deployment (empty `RESIN_PROXY_TOKEN`) and uses a readable `<token>` placeholder when the token field is empty.
- URL components are individually percent-encoded; structural separators stay literal.

## Changes
- `internal/api/handler_system.go` — add `auth_version` to env config response.
- `webui/src/features/platforms/PlatformAccessPanel.tsx` — new access panel (URL builders + copy buttons).
- `webui/src/features/platforms/PlatformDetailPage.tsx` — new 接入 tab.
- `webui/src/features/systemConfig/types.ts` — `auth_version` field.
- `webui/src/i18n/translations.ts` — zh→en mappings.
- `webui/src/styles/theme.css` — access panel styles.

## Test plan
- [x] `go test ./internal/api/` passes; `gofmt`/`go vet` clean
- [x] `tsc -b` typecheck passes; `eslint` clean on changed files
- [x] `vite build` succeeds
- [x] Manually verified in browser: generated HTTP/SOCKS5/reverse URLs and curl snippets match the documented formats; copy buttons work; token persists locally