### PR TITLE
feat(outbound): add optional RESIN_UPSTREAM_PROXY for global node egress

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,7 @@ RESIN_ADMIN_TOKEN=change-me-admin-token
 # Set RESIN_PROXY_TOKEN= to disable proxy authentication.
 RESIN_PROXY_TOKEN=change-me-proxy-token
 RESIN_PORT=2260
+
+# Optional: route every node outbound through an upstream proxy.
+# Supported: socks5://, http://, https://, or host:port (defaults to http).
+# RESIN_UPSTREAM_PROXY=socks5://127.0.0.1:1080

--- a/README.md
+++ b/README.md
@@ -367,6 +367,8 @@ RESIN_PORT=2260 \
 
 ## 🛠️ FAQ
 
+- **Q: How do I route all node outbounds through an upstream proxy?**
+  - **A**: Set `RESIN_UPSTREAM_PROXY` to any SOCKS5/HTTP/HTTPS proxy URL. Every managed node then dials through that upstream instead of connecting directly from the Resin host/container. Examples: `RESIN_UPSTREAM_PROXY="socks5://127.0.0.1:1080"`, `RESIN_UPSTREAM_PROXY="http://proxy.example.com:8080"`, `RESIN_UPSTREAM_PROXY="https://user:pass@proxy.example.com:8443"`. Scheme-less `host:port` is treated as HTTP. Existing node-level detours are preserved. Leave it empty to keep the default direct dialing behavior.
 - **Q: How do I let LAN or localhost targets skip proxy nodes?**
   - **A**: Set `RESIN_PROXY_BYPASS` to a semicolon/comma/newline-separated rule list. Matching requests are dialed directly by Resin instead of through a proxy node. Example: `RESIN_PROXY_BYPASS="localhost;127.*;10.*;172.16.0.0/12;192.168.*;<local>"`. Supported rules include exact hosts, `*`/`?` wildcards, CIDR ranges, and `<local>` for hostnames without dots.
 - **Q: Startup fails with `RESIN_PROXY_TOKEN` undefined?**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -353,6 +353,8 @@ RESIN_PORT=2260 \
 
 ## 🛠️ 常见错误 (FAQ)
 
+- **Q: 如何让所有节点出站统一走上游代理？**
+  - **A**: 配置 `RESIN_UPSTREAM_PROXY` 为任意 SOCKS5/HTTP/HTTPS 代理地址。之后每个托管节点都会经该上游出站，而不是从 Resin 主机/容器直连。例如：`RESIN_UPSTREAM_PROXY="socks5://127.0.0.1:1080"`、`RESIN_UPSTREAM_PROXY="http://proxy.example.com:8080"`、`RESIN_UPSTREAM_PROXY="https://user:pass@proxy.example.com:8443"`。裸写 `host:port` 时按 HTTP 处理。若节点自身已有 detour，会保留节点级配置。留空则保持默认直连行为。
 - **Q: 如何让内网或本机目标不走代理节点？**
   - **A**: 配置 `RESIN_PROXY_BYPASS`，用分号、逗号或换行分隔规则。命中的请求会由 Resin 本机直连目标，而不是通过代理节点。例如：`RESIN_PROXY_BYPASS="localhost;127.*;10.*;172.16.0.0/12;192.168.*;<local>"`。规则支持精确主机、`*`/`?` 通配符、CIDR 网段，以及表示无点号本地域名的 `<local>`。
 - **Q: 启动失败提示 `RESIN_PROXY_TOKEN` 未定义？**

--- a/cmd/resin/main.go
+++ b/cmd/resin/main.go
@@ -240,7 +240,8 @@ func newTopologyRuntime(
 	log.Println("Topology: GlobalNodePool initialized")
 
 	singboxBuilder, err := outbound.NewSingboxBuilderWithConfig(outbound.SingboxBuilderConfig{
-		DNSUpstreams: envCfg.NodeDNSUpstreams,
+		DNSUpstreams:  envCfg.NodeDNSUpstreams,
+		UpstreamProxy: envCfg.UpstreamProxy,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("singbox builder: %w", err)

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -22,6 +22,7 @@ type EnvConfig struct {
 
 	// Network
 	ListenAddress string
+	UpstreamProxy string
 
 	// Ports
 	ResinPort       int
@@ -91,6 +92,7 @@ func LoadEnvConfig() (*EnvConfig, error) {
 	cfg.StateDir = envStr("RESIN_STATE_DIR", "/var/lib/resin")
 	cfg.LogDir = envStr("RESIN_LOG_DIR", "/var/log/resin")
 	cfg.ListenAddress = strings.TrimSpace(envStr("RESIN_LISTEN_ADDRESS", "0.0.0.0"))
+	cfg.UpstreamProxy = strings.TrimSpace(envStr("RESIN_UPSTREAM_PROXY", ""))
 
 	// --- Ports ---
 	cfg.ResinPort = envInt("RESIN_PORT", 2260, &errs)

--- a/internal/outbound/builder.go
+++ b/internal/outbound/builder.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/adapter/endpoint"
@@ -29,6 +30,12 @@ type SingboxBuilderConfig struct {
 	// DNSUpstreams configures Resin's node DNS chain.
 	// Values are DNS upstream URI strings and the slice must not be empty.
 	DNSUpstreams []string
+
+	// UpstreamProxy optionally routes every node outbound through a generic
+	// upstream proxy via a sing-box detour chain. Accepted forms:
+	// socks5://[user:pass@]host:port, http://[user:pass@]host:port,
+	// https://[user:pass@]host:port, or scheme-less host:port (http).
+	UpstreamProxy string
 }
 
 // ---------------------------------------------------------------------------
@@ -44,6 +51,7 @@ type SingboxBuilder struct {
 	logFactory          log.Factory
 	dnsTransportManager *dns.TransportManager
 	dnsRouter           *dns.Router
+	upstreamProxy       adapter.Outbound
 }
 
 // NewSingboxBuilderWithConfig creates a SingboxBuilder with a complete
@@ -116,13 +124,33 @@ func NewSingboxBuilderWithConfig(cfg SingboxBuilderConfig) (*SingboxBuilder, err
 
 	registry := service.FromContext[adapter.OutboundRegistry](ctx).(*sbOutbound.Registry)
 
-	return &SingboxBuilder{
+	builder := &SingboxBuilder{
 		registry:            registry,
 		ctx:                 ctx,
 		logFactory:          logFactory,
 		dnsTransportManager: dnsTransportMgr,
 		dnsRouter:           dnsRouter,
-	}, nil
+	}
+
+	// Optionally route every node outbound through a generic upstream proxy
+	// via a sing-box detour chain.
+	if strings.TrimSpace(cfg.UpstreamProxy) != "" {
+		upstream, err := createUpstreamProxy(
+			ctx,
+			outboundMgr,
+			dnsTransportMgr,
+			logger,
+			cfg.UpstreamProxy,
+		)
+		if err != nil {
+			_ = dnsRouter.Close()
+			_ = dnsTransportMgr.Close()
+			return nil, err
+		}
+		builder.upstreamProxy = upstream
+	}
+
+	return builder, nil
 }
 
 // Build parses rawOptions (a complete sing-box outbound JSON object with
@@ -134,6 +162,13 @@ func (b *SingboxBuilder) Build(rawOptions json.RawMessage) (adapter.Outbound, er
 	var outboundConfig option.Outbound
 	if err := sJson.UnmarshalContext(b.ctx, rawOptions, &outboundConfig); err != nil {
 		return nil, fmt.Errorf("parse outbound options: %w", err)
+	}
+
+	// 1b. When an upstream proxy is configured, detour every node outbound
+	//     through it so node connections egress via the proxy instead of the
+	//     container's direct route. Existing node-level detours win.
+	if b.upstreamProxy != nil {
+		injectUpstreamProxyDetour(outboundConfig.Options)
 	}
 
 	// 2. Create the outbound instance via the registry.
@@ -161,9 +196,13 @@ func (b *SingboxBuilder) Build(rawOptions json.RawMessage) (adapter.Outbound, er
 	return ob, nil
 }
 
-// Close shuts down the builder's internal DNS services.
+// Close releases the upstream outbound (if any) and shuts down the builder's
+// internal DNS services.
 func (b *SingboxBuilder) Close() error {
 	var errs []error
+	if b.upstreamProxy != nil {
+		errs = append(errs, common.Close(b.upstreamProxy))
+	}
 	if b.dnsRouter != nil {
 		errs = append(errs, b.dnsRouter.Close())
 	}

--- a/internal/outbound/upstream_proxy.go
+++ b/internal/outbound/upstream_proxy.go
@@ -1,0 +1,209 @@
+package outbound
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/sagernet/sing-box/adapter"
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing/common"
+)
+
+const (
+	// upstreamProxyOutboundTag is the sing-box outbound tag every node
+	// outbound detours through when RESIN_UPSTREAM_PROXY is configured.
+	upstreamProxyOutboundTag = "__resin_upstream_proxy"
+
+	// upstreamProxyLocalDNSTransportTag is a dedicated "local" DNS transport
+	// used to resolve the upstream proxy server hostname via the system
+	// resolver (docker DNS / /etc/hosts) when it is a domain name.
+	upstreamProxyLocalDNSTransportTag = "resin-upstream-proxy-local-dns"
+)
+
+// upstreamProxySpec is a parsed RESIN_UPSTREAM_PROXY value ready to be turned
+// into a sing-box outbound.
+type upstreamProxySpec struct {
+	outboundType   string // "socks" or "http"
+	options        any    // *option.SOCKSOutboundOptions or *option.HTTPOutboundOptions
+	serverIsDomain bool
+}
+
+// parseUpstreamProxyURL parses a proxy URI of the form
+//
+//	socks5://[user:pass@]host:port
+//	http://[user:pass@]host:port
+//	https://[user:pass@]host:port
+//	host:port  (scheme-less, treated as http)
+//
+// Default ports: socks 1080, http 80, https 443.
+func parseUpstreamProxyURL(raw string) (upstreamProxySpec, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return upstreamProxySpec{}, fmt.Errorf("empty upstream proxy URL")
+	}
+	if !strings.Contains(raw, "://") {
+		raw = "http://" + raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return upstreamProxySpec{}, fmt.Errorf("parse upstream proxy URL: %w", err)
+	}
+	scheme := strings.ToLower(u.Scheme)
+	switch scheme {
+	case "socks", "socks5", "socks5h", "http", "https":
+	default:
+		return upstreamProxySpec{}, fmt.Errorf(
+			"unsupported upstream proxy scheme %q (supported: socks5://, http://, https://)",
+			scheme,
+		)
+	}
+	host := strings.TrimSpace(u.Hostname())
+	if host == "" {
+		return upstreamProxySpec{}, fmt.Errorf("upstream proxy URL: missing host")
+	}
+	port, err := upstreamProxyPort(u, scheme)
+	if err != nil {
+		return upstreamProxySpec{}, err
+	}
+	_, parseErr := netip.ParseAddr(host)
+	hostIsIP := parseErr == nil
+	var username, password string
+	if u.User != nil {
+		username = u.User.Username()
+		password, _ = u.User.Password()
+	}
+	serverOptions := option.ServerOptions{
+		Server:     host,
+		ServerPort: uint16(port),
+	}
+	switch scheme {
+	case "socks", "socks5", "socks5h":
+		return upstreamProxySpec{
+			outboundType:   C.TypeSOCKS,
+			serverIsDomain: !hostIsIP,
+			options: &option.SOCKSOutboundOptions{
+				ServerOptions: serverOptions,
+				Version:       "5",
+				Username:      username,
+				Password:      password,
+			},
+		}, nil
+	default: // http, https
+		opts := &option.HTTPOutboundOptions{
+			ServerOptions: serverOptions,
+			Username:      username,
+			Password:      password,
+		}
+		if scheme == "https" {
+			opts.OutboundTLSOptionsContainer.TLS = &option.OutboundTLSOptions{
+				ServerName: host,
+			}
+		}
+		return upstreamProxySpec{
+			outboundType:   C.TypeHTTP,
+			serverIsDomain: !hostIsIP,
+			options:        opts,
+		}, nil
+	}
+}
+
+func upstreamProxyPort(u *url.URL, scheme string) (int, error) {
+	if rawPort := u.Port(); rawPort != "" {
+		p, err := strconv.Atoi(rawPort)
+		if err != nil || p < 1 || p > 65535 {
+			return 0, fmt.Errorf("upstream proxy URL: invalid port %q", rawPort)
+		}
+		return p, nil
+	}
+	switch scheme {
+	case "socks", "socks5", "socks5h":
+		return 1080, nil
+	case "https":
+		return 443, nil
+	default:
+		return 80, nil
+	}
+}
+
+// createUpstreamProxy builds the dedicated upstream outbound and registers it
+// in the given outbound manager so that node outbounds can detour through it.
+// When the proxy server is a domain name, a dedicated system-resolver DNS
+// transport is registered so the hostname resolves inside the container.
+func createUpstreamProxy(
+	ctx context.Context,
+	outboundMgr adapter.OutboundManager,
+	dnsTransportMgr adapter.DNSTransportManager,
+	logger log.ContextLogger,
+	raw string,
+) (adapter.Outbound, error) {
+	spec, err := parseUpstreamProxyURL(raw)
+	if err != nil {
+		return nil, fmt.Errorf("upstream proxy: %w", err)
+	}
+	if spec.serverIsDomain {
+		if err := dnsTransportMgr.Create(
+			ctx,
+			logger,
+			upstreamProxyLocalDNSTransportTag,
+			C.DNSTypeLocal,
+			&option.LocalDNSServerOptions{},
+		); err != nil {
+			return nil, fmt.Errorf("upstream proxy: register local DNS resolver: %w", err)
+		}
+		setUpstreamProxyDomainResolver(spec.options, upstreamProxyLocalDNSTransportTag)
+	}
+	if err := outboundMgr.Create(
+		ctx,
+		nil, // router - dialing does not require one
+		logger,
+		upstreamProxyOutboundTag,
+		spec.outboundType,
+		spec.options,
+	); err != nil {
+		return nil, fmt.Errorf("upstream proxy: create outbound: %w", err)
+	}
+	ob, loaded := outboundMgr.Outbound(upstreamProxyOutboundTag)
+	if !loaded || ob == nil {
+		return nil, fmt.Errorf("upstream proxy: registered outbound %q not found", upstreamProxyOutboundTag)
+	}
+	// The outbound manager is never started in this service graph, so run the
+	// lifecycle stages manually, matching SingboxBuilder.Build.
+	for _, stage := range adapter.ListStartStages {
+		if err := adapter.LegacyStart(ob, stage); err != nil {
+			_ = common.Close(ob)
+			return nil, fmt.Errorf("upstream proxy: start %s: %w", stage, err)
+		}
+	}
+	return ob, nil
+}
+
+func setUpstreamProxyDomainResolver(options any, resolverTag string) {
+	switch opts := options.(type) {
+	case *option.SOCKSOutboundOptions:
+		opts.DialerOptions.DomainResolver = &option.DomainResolveOptions{Server: resolverTag}
+	case *option.HTTPOutboundOptions:
+		opts.DialerOptions.DomainResolver = &option.DomainResolveOptions{Server: resolverTag}
+	}
+}
+
+// injectUpstreamProxyDetour rewrites an outbound's dialer options so that its
+// server connections go through the upstream proxy. An existing detour on the
+// node is preserved (node-level detours take precedence).
+func injectUpstreamProxyDetour(options any) {
+	wrapper, ok := options.(option.DialerOptionsWrapper)
+	if !ok {
+		return
+	}
+	dialOptions := wrapper.TakeDialerOptions()
+	if dialOptions.Detour != "" {
+		return
+	}
+	dialOptions.Detour = upstreamProxyOutboundTag
+	wrapper.ReplaceDialerOptions(dialOptions)
+}

--- a/internal/outbound/upstream_proxy_test.go
+++ b/internal/outbound/upstream_proxy_test.go
@@ -1,0 +1,192 @@
+package outbound
+
+import (
+	"testing"
+
+	"github.com/sagernet/sing-box/option"
+)
+
+// ---------------------------------------------------------------------------
+// parseUpstreamProxyURL
+// ---------------------------------------------------------------------------
+
+func TestParseUpstreamProxy_Socks5(t *testing.T) {
+	spec, err := parseUpstreamProxyURL("socks5://proxy.example.local:1080")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.outboundType != "socks" {
+		t.Fatalf("outboundType: got %q, want %q", spec.outboundType, "socks")
+	}
+	if !spec.serverIsDomain {
+		t.Fatal("serverIsDomain: expected true for hostname")
+	}
+	opts, ok := spec.options.(*option.SOCKSOutboundOptions)
+	if !ok {
+		t.Fatalf("options type: got %T, want *option.SOCKSOutboundOptions", spec.options)
+	}
+	if opts.Server != "proxy.example.local" || opts.ServerPort != 1080 {
+		t.Fatalf("server: got %s:%d, want proxy.example.local:1080", opts.Server, opts.ServerPort)
+	}
+	if opts.Version != "5" {
+		t.Fatalf("socks version: got %q, want %q", opts.Version, "5")
+	}
+}
+
+func TestParseUpstreamProxy_Socks4(t *testing.T) {
+	spec, err := parseUpstreamProxyURL("socks://10.0.0.1:3128")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.serverIsDomain {
+		t.Fatal("serverIsDomain: expected false for IP address")
+	}
+	opts, ok := spec.options.(*option.SOCKSOutboundOptions)
+	if !ok {
+		t.Fatalf("options type: got %T, want *option.SOCKSOutboundOptions", spec.options)
+	}
+	if opts.Server != "10.0.0.1" || opts.ServerPort != 3128 {
+		t.Fatalf("server: got %s:%d", opts.Server, opts.ServerPort)
+	}
+}
+
+func TestParseUpstreamProxy_HTTP(t *testing.T) {
+	spec, err := parseUpstreamProxyURL("http://host.docker.internal:20171")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.outboundType != "http" {
+		t.Fatalf("outboundType: got %q, want %q", spec.outboundType, "http")
+	}
+	if !spec.serverIsDomain {
+		t.Fatal("serverIsDomain: expected true for hostname")
+	}
+	opts, ok := spec.options.(*option.HTTPOutboundOptions)
+	if !ok {
+		t.Fatalf("options type: got %T, want *option.HTTPOutboundOptions", spec.options)
+	}
+	if opts.Server != "host.docker.internal" || opts.ServerPort != 20171 {
+		t.Fatalf("server: got %s:%d", opts.Server, opts.ServerPort)
+	}
+}
+
+func TestParseUpstreamProxy_SchemeLess(t *testing.T) {
+	spec, err := parseUpstreamProxyURL("192.168.1.1:8080")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.outboundType != "http" {
+		t.Fatalf("outboundType: got %q, want %q", spec.outboundType, "http")
+	}
+	if spec.serverIsDomain {
+		t.Fatal("serverIsDomain: expected false for IP address")
+	}
+}
+
+func TestParseUpstreamProxy_HTTPS(t *testing.T) {
+	spec, err := parseUpstreamProxyURL("https://proxy.example.com:8443")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.outboundType != "http" {
+		t.Fatalf("outboundType: got %q, want %q", spec.outboundType, "http")
+	}
+	opts, ok := spec.options.(*option.HTTPOutboundOptions)
+	if !ok {
+		t.Fatalf("options type: got %T, want *option.HTTPOutboundOptions", spec.options)
+	}
+	if opts.TLS == nil {
+		t.Fatal("expected TLS config for https scheme")
+	}
+	if opts.TLS != nil && opts.TLS.ServerName != "proxy.example.com" {
+		t.Fatalf("TLS ServerName: got %q, want %q", opts.TLS.ServerName, "proxy.example.com")
+	}
+}
+
+func TestParseUpstreamProxy_WithAuth(t *testing.T) {
+	spec, err := parseUpstreamProxyURL("socks5://user:pass@proxy.example.local:1080")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	opts, ok := spec.options.(*option.SOCKSOutboundOptions)
+	if !ok {
+		t.Fatalf("options type: got %T", spec.options)
+	}
+	if opts.Username != "user" || opts.Password != "pass" {
+		t.Fatalf("auth: got %s:%s, want user:pass", opts.Username, opts.Password)
+	}
+}
+
+func TestParseUpstreamProxy_DefaultPorts(t *testing.T) {
+	cases := []struct {
+		raw      string
+		wantPort uint16
+	}{
+		{"socks5://host", 1080},
+		{"http://host", 80},
+		{"https://host", 443},
+	}
+	for _, tc := range cases {
+		spec, err := parseUpstreamProxyURL(tc.raw)
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", tc.raw, err)
+		}
+		switch opts := spec.options.(type) {
+		case *option.SOCKSOutboundOptions:
+			if opts.ServerPort != tc.wantPort {
+				t.Fatalf("%s: port got %d, want %d", tc.raw, opts.ServerPort, tc.wantPort)
+			}
+		case *option.HTTPOutboundOptions:
+			if opts.ServerPort != tc.wantPort {
+				t.Fatalf("%s: port got %d, want %d", tc.raw, opts.ServerPort, tc.wantPort)
+			}
+		}
+	}
+}
+
+func TestParseUpstreamProxy_Invalid(t *testing.T) {
+	invalid := []string{
+		"",
+		"://host",
+		"ftp://proxy",
+		"socks5://:0",
+	}
+	for _, raw := range invalid {
+		_, err := parseUpstreamProxyURL(raw)
+		if err == nil {
+			t.Fatalf("expected error for %q", raw)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// injectUpstreamProxyDetour
+// ---------------------------------------------------------------------------
+
+func TestInjectUpstreamProxyDetour_SOCKS(t *testing.T) {
+	opts := &option.SOCKSOutboundOptions{
+		ServerOptions: option.ServerOptions{Server: "node.example.com", ServerPort: 443},
+	}
+	injectUpstreamProxyDetour(opts)
+	if opts.Detour != upstreamProxyOutboundTag {
+		t.Fatalf("Detour: got %q, want %q", opts.Detour, upstreamProxyOutboundTag)
+	}
+}
+
+func TestInjectUpstreamProxyDetour_PreservesExisting(t *testing.T) {
+	opts := &option.SOCKSOutboundOptions{
+		DialerOptions: option.DialerOptions{
+			Detour: "custom-detour",
+		},
+	}
+	injectUpstreamProxyDetour(opts)
+	if opts.Detour != "custom-detour" {
+		t.Fatalf("Detour overwritten: got %q, want %q", opts.Detour, "custom-detour")
+	}
+}
+
+func TestInjectUpstreamProxyDetour_UnsupportedType(t *testing.T) {
+	// A struct that does not embed DialerOptions should be skipped.
+	injectUpstreamProxyDetour("not-a-pointer-struct")
+	// No panic — just no-op.
+}


### PR DESCRIPTION
## Summary

Add an opt-in environment variable `RESIN_UPSTREAM_PROXY` that routes every managed node outbound through a configurable upstream proxy.

This is a generic dial-chain option for any SOCKS5/HTTP/HTTPS proxy. It is not tied to a specific product or vendor integration.

## Motivation

Some deployments need all managed nodes to egress through an intermediate proxy instead of dialing directly from the Resin host/container.

Today Resin builds node outbounds with direct dialing. Operators who need a shared egress path must either change host networking or rewrite each node config.

This change provides a single opt-in control for that deployment pattern.

## What changed

- New env var: `RESIN_UPSTREAM_PROXY`
- Supported forms:
  - `socks5://[user:pass@]host:port`
  - `socks5h://[user:pass@]host:port`
  - `http://[user:pass@]host:port`
  - `https://[user:pass@]host:port`
  - scheme-less `host:port` (treated as HTTP)
- Implementation injects a dedicated sing-box outbound and sets each node `DialerOptions.Detour`
- Existing node-level detours are preserved
- If the upstream proxy host is a domain name, a local DNS transport is registered for resolution
- When the env is empty, behavior is unchanged

## Non-goals

- Not a product-specific integration
- Not per-node / per-platform upstream selection
- Not multi-upstream load balancing
- Not support for arbitrary non-SOCKS5/HTTP/HTTPS proxy protocols

## Compatibility

- Fully opt-in
- Empty / unset `RESIN_UPSTREAM_PROXY` preserves current direct dialing behavior
- Existing node-level detours continue to take precedence

## Docs

- `.env.example` documents the new variable
- FAQ entries added in `README.md` and `README.zh-CN.md`

## Test plan

- [x] `go test ./internal/outbound/ -count=1`
- [x] `go test ./internal/config/ -count=1`
- [x] URL parsing coverage for socks5 / http / https / scheme-less
- [x] Auth parsing coverage
- [x] Default ports coverage
- [x] Detour injection and existing-detour preservation coverage
- [ ] Manual check: leave env empty and confirm direct dialing still works
- [ ] Manual check: set `RESIN_UPSTREAM_PROXY=socks5://127.0.0.1:1080` and confirm node egress goes through that proxy
- [ ] Manual check: set an HTTP upstream and confirm the same
- [ ] Manual check: node with an existing detour still keeps its own detour

## Example

```bash
RESIN_UPSTREAM_PROXY=socks5://127.0.0.1:1080
RESIN_UPSTREAM_PROXY=http://proxy.example.com:8080
RESIN_UPSTREAM_PROXY=https://user:pass@proxy.example.com:8443
```