### PR TITLE
feat: 支持 HTTP 正向代理通过 X-Resin-Platform 指定平台

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -63,6 +63,7 @@
    * 接入点可随时配置“当系统未设定代理令牌时，也强制客户端发送代理认证信息”（默认关闭）。`RESIN_PROXY_TOKEN` 非空时始终执行令牌认证；为空且此选项启用时，HTTP 正向代理缺少可解析且非空的 Basic 用户名会返回 407，SOCKS5 仅接受 `0x02` 并要求用户名和密码均非空，但不校验密码内容。空令牌下，此选项只用于强制携带身份，不构成安全认证。当启用此选项，客户端发来空认证不再视为 Default 平台请求。
 4. HTTP 正向代理：
    * 格式：`Proxy-Authorization: Basic Platform.Account:PROXY_TOKEN`（user=Platform.Account，pass=PROXY_TOKEN）；解析时先按最右侧 `:` 切 Token，再对左侧身份串按第一个出现的 `.` 或 `:` 切 `Platform` 与 `Account`。
+   * 可选请求头 `X-Resin-Platform` 在代理认证成功后为缺失的 Platform 提供值；若认证身份中已有 Platform，则以认证中的 Platform 为准。该头只用于 Resin 路由，普通 HTTP 转发到目标前会删除；HTTPS `CONNECT` 只在建隧道时消费，不会进入隧道。代理 Token 仍按原规则校验。
 5. SOCKS5 正向代理：
    * 仅支持 SOCKS5 `CONNECT`；成功后进入原始双向 TCP 隧道。
    * `RESIN_PROXY_TOKEN` 非空时，仅接受 RFC1929 用户名密码认证（method `0x02`）：`username=<Platform.Account|Platform:Account>`，`password=<PROXY_TOKEN>`。

--- a/README.md
+++ b/README.md
@@ -225,6 +225,12 @@ curl --proxy socks5h://127.0.0.1:2260 \
   https://api.ipify.org
 ```
 
+For HTTP forward proxy clients, `X-Resin-Platform` can supply the Platform
+when the authenticated identity does not contain one. An explicit Platform in
+`Proxy-Authorization` takes precedence. The header is consumed by Resin and
+removed before normal HTTP forwarding; it is also accepted on HTTPS `CONNECT`
+during tunnel setup.
+
 #### Method 2: Reverse proxy (URL Account, quick/manual debug)
 
 By replacing your service BaseURL with Resin reverse-proxy URL, traffic goes through Resin directly.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -215,6 +215,11 @@ curl --proxy socks5h://127.0.0.1:2260 \
   https://api.ipify.org
 ```
 
+当认证身份中没有 Platform 时，HTTP 正向代理也可以使用
+`X-Resin-Platform` 请求头提供 Platform。如果 `Proxy-Authorization` 中
+已经包含 Platform，则以认证身份为准。该请求头只用于 Resin 路由，普通
+HTTP 转发前会删除，HTTPS `CONNECT` 只在建立隧道时使用。
+
 #### 方式二：反向代理接入（URL 携带 Account，适合简单使用/手动调试）
 你可以通过替换业务的 BaseURL 为 Resin 反代地址，将请求直接发给 Resin。
 URL 格式进阶为：`http://部署IP:2260/密码/平台.账号/协议/目标地址`：

--- a/internal/proxy/e2e_test.go
+++ b/internal/proxy/e2e_test.go
@@ -116,6 +116,9 @@ func TestForwardProxy_E2EHTTPSuccess(t *testing.T) {
 		if got := r.Header.Get("Proxy-Authorization"); got != "" {
 			t.Fatalf("Proxy-Authorization leaked to upstream: %q", got)
 		}
+		if got := r.Header.Get("X-Resin-Platform"); got != "" {
+			t.Fatalf("X-Resin-Platform leaked to upstream: %q", got)
+		}
 		if got := r.URL.Path; got != "/v1/ping" {
 			t.Fatalf("unexpected path: %q", got)
 		}
@@ -137,7 +140,8 @@ func TestForwardProxy_E2EHTTPSuccess(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, upstream.URL+"/v1/ping?q=1", nil)
-	req.Header.Set("Proxy-Authorization", basicAuth("plat", "tok"))
+	req.Header.Set("Proxy-Authorization", basicAuth("", "tok"))
+	req.Header.Set("X-Resin-Platform", "plat")
 	req.Header.Set("X-Test", "1")
 	w := httptest.NewRecorder()
 
@@ -156,6 +160,9 @@ func TestForwardProxy_E2EHTTPSuccess(t *testing.T) {
 
 	select {
 	case logEv := <-emitter.logCh:
+		if logEv.PlatformName != "plat" {
+			t.Fatalf("Platform: got %q, want %q", logEv.PlatformName, "plat")
+		}
 		if logEv.EgressBytes <= 0 {
 			t.Fatalf("EgressBytes: got %d, want > 0", logEv.EgressBytes)
 		}
@@ -739,10 +746,11 @@ func TestForwardProxy_CONNECTTunnelSemantics(t *testing.T) {
 
 	targetAddr := targetLn.Addr().String()
 	req := fmt.Sprintf(
-		"CONNECT %s HTTP/1.1\r\nHost: %s\r\nProxy-Authorization: %s\r\n\r\n",
+		"CONNECT %s HTTP/1.1\r\nHost: %s\r\nProxy-Authorization: %s\r\nX-Resin-Platform: %s\r\n\r\n",
 		targetAddr,
 		targetAddr,
-		basicAuth("plat", "tok"),
+		basicAuth("", "tok"),
+		"plat",
 	)
 	if _, err := clientConn.Write([]byte(req)); err != nil {
 		t.Fatalf("write connect request: %v", err)
@@ -786,6 +794,9 @@ func TestForwardProxy_CONNECTTunnelSemantics(t *testing.T) {
 
 	select {
 	case logEv := <-emitter.logCh:
+		if logEv.PlatformName != "plat" {
+			t.Fatalf("CONNECT Platform: got %q, want %q", logEv.PlatformName, "plat")
+		}
 		if !logEv.NetOK {
 			t.Fatal("CONNECT log net_ok: got false, want true")
 		}

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -126,6 +126,21 @@ func (p *ForwardProxy) authenticateV1(r *http.Request) (string, string, *ProxyEr
 	return platName, account, nil
 }
 
+// resolveForwardProxyPlatform applies the optional HTTP forward-proxy
+// platform header after proxy authentication has succeeded. An explicit
+// Platform in Proxy-Authorization wins; the header only fills a missing one.
+func resolveForwardProxyPlatform(r *http.Request, authenticatedPlatform string) string {
+	if authenticatedPlatform != "" {
+		return authenticatedPlatform
+	}
+	if r != nil {
+		if platform := r.Header.Get("X-Resin-Platform"); platform != "" {
+			return platform
+		}
+	}
+	return authenticatedPlatform
+}
+
 func requireProxyAuthInfo(r *http.Request) bool {
 	return r != nil && InboundPolicyFromContext(r.Context()).RequireProxyAuthInfo
 }
@@ -211,6 +226,8 @@ func prepareForwardOutboundRequest(in *http.Request) *http.Request {
 	// Do not propagate client-side close semantics to upstream transport reuse.
 	req.Close = false
 	stripHopByHopHeaders(req.Header)
+	// This header controls Resin routing and must not be exposed to the target.
+	req.Header.Del("X-Resin-Platform")
 	return req
 }
 
@@ -220,6 +237,7 @@ func (p *ForwardProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		writeProxyError(w, authErr)
 		return
 	}
+	platName = resolveForwardProxyPlatform(r, platName)
 
 	lifecycle := newRequestLifecycle(p.events, r, ProxyTypeForward, false)
 	lifecycle.setTarget(r.Host, r.URL.String())
@@ -318,6 +336,7 @@ func (p *ForwardProxy) handleCONNECT(w http.ResponseWriter, r *http.Request) {
 		writeProxyError(w, authErr)
 		return
 	}
+	platName = resolveForwardProxyPlatform(r, platName)
 
 	lifecycle := newRequestLifecycle(p.events, r, ProxyTypeForward, true)
 	lifecycle.setTarget(target, "")

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -196,6 +196,7 @@ func TestForwardProxy_AuthFailed(t *testing.T) {
 	fp := &ForwardProxy{token: "correct-token", events: NoOpEventEmitter{}}
 	req := httptest.NewRequest("GET", "http://example.com/", nil)
 	req.Header.Set("Proxy-Authorization", basicAuth("plat.acct", "wrong-token"))
+	req.Header.Set("X-Resin-Platform", "header-platform")
 	w := httptest.NewRecorder()
 	fp.ServeHTTP(w, req)
 
@@ -204,6 +205,24 @@ func TestForwardProxy_AuthFailed(t *testing.T) {
 	}
 	if w.Header().Get("X-Resin-Error") != "AUTH_FAILED" {
 		t.Fatalf("expected AUTH_FAILED, got %q", w.Header().Get("X-Resin-Error"))
+	}
+}
+
+func TestResolveForwardProxyPlatform_HeaderSuppliesMissingAuthenticatedPlatform(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req.Header.Set("X-Resin-Platform", "header-platform")
+
+	if got := resolveForwardProxyPlatform(req, ""); got != "header-platform" {
+		t.Fatalf("platform: got %q, want %q", got, "header-platform")
+	}
+}
+
+func TestResolveForwardProxyPlatform_AuthenticatedPlatformWinsOverHeader(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req.Header.Set("X-Resin-Platform", "header-platform")
+
+	if got := resolveForwardProxyPlatform(req, "auth-platform"); got != "auth-platform" {
+		t.Fatalf("platform: got %q, want %q", got, "auth-platform")
 	}
 }
 
@@ -435,6 +454,7 @@ func TestPrepareForwardOutboundRequest_NormalizesClientCloseAndHeaders(t *testin
 	req.RequestURI = "http://example.com/path?q=1"
 	req.Close = true
 	req.Header.Set("Proxy-Authorization", "Basic xxx")
+	req.Header.Set("X-Resin-Platform", "header-platform")
 	req.Header.Set("Connection", "close, X-Custom-Header")
 	req.Header.Set("X-Custom-Header", "value")
 	req.Header.Set("X-Normal-Header", "keep")
@@ -453,6 +473,9 @@ func TestPrepareForwardOutboundRequest_NormalizesClientCloseAndHeaders(t *testin
 	if out.Header.Get("Proxy-Authorization") != "" {
 		t.Fatal("Proxy-Authorization should be stripped")
 	}
+	if out.Header.Get("X-Resin-Platform") != "" {
+		t.Fatal("X-Resin-Platform should be stripped")
+	}
 	if out.Header.Get("X-Custom-Header") != "" {
 		t.Fatal("connection-listed header should be stripped")
 	}
@@ -469,6 +492,9 @@ func TestPrepareForwardOutboundRequest_NormalizesClientCloseAndHeaders(t *testin
 	}
 	if req.Header.Get("Proxy-Authorization") == "" {
 		t.Fatal("original Proxy-Authorization should remain unchanged")
+	}
+	if req.Header.Get("X-Resin-Platform") == "" {
+		t.Fatal("original X-Resin-Platform should remain unchanged")
 	}
 	if req.Header.Get("X-Custom-Header") == "" {
 		t.Fatal("original custom header should remain unchanged")


### PR DESCRIPTION
## 概述

为 HTTP 正向代理增加 `X-Resin-Platform` 请求头支持，使客户端可以通过请求头补充 Resin 的 Platform。

## 行为

- `Proxy-Authorization` 中已有 Platform 时，以认证信息中的 Platform 为准。
- 当认证信息没有 Platform 时，使用 `X-Resin-Platform`。
- 两者都没有时，继续使用默认 `Default` Platform。
- HTTP 普通请求和 HTTPS `CONNECT` 均支持该请求头。
- 普通 HTTP 转发到目标服务前会删除 `X-Resin-Platform`。
- `CONNECT` 只在建立隧道时使用该请求头，不会将其传入隧道。
- Token 认证逻辑保持不变，请求头不能绕过认证。
- SOCKS5 不在本次修改范围内。

## 测试

- 增加 Platform 请求头 fallback 测试。
- 增加认证 Platform 优先级测试。
- 增加请求头剥离测试。
- 增加 HTTP 正向代理 E2E 测试。
- 增加 CONNECT 隧道 E2E 测试。

`go test ./internal/proxy` 通过。