### PR TITLE
fix(migrations): add missing 000009 down migration

### DIFF
--- a/internal/state/migrations/state/000009_platform_regex_filter_rules.down.sql
+++ b/internal/state/migrations/state/000009_platform_regex_filter_rules.down.sql
@@ -1,0 +1,2 @@
+-- Irreversible migration (see 000009 up). No-op: keep the migrated schema;
+-- restoring the previous regex_filters_json format requires a pre-upgrade backup.


### PR DESCRIPTION
## Problem

"internal/state/migrations/state/000009_platform_regex_filter_rules.up.sql" has no matching down file. golang-migrate's iofs source requires both up and down files to be registered, so a state.db already at version 9 makes the server fail to bootstrap:

`
fatal: persistence bootstrap: migrate state.db: migrate migrations/state: up: no migration found for version 9: read down for version 9
`

## Fix

Add a documented no-op down migration (the up migration is irreversible by design; restoring the previous egex_filters_json format requires a pre-upgrade backup).