### PR TITLE
feat(api): expose per-node domain latency summaries in node list

### DIFF
--- a/internal/service/control_plane_nodes_test.go
+++ b/internal/service/control_plane_nodes_test.go
@@ -298,6 +298,62 @@ func TestGetNode_ReferenceLatencyMsUsesAuthorityAverage(t *testing.T) {
 	}
 }
 
+func TestGetNode_IncludesPerDomainLatencies(t *testing.T) {
+	subMgr := topology.NewSubscriptionManager()
+	pool := newNodeListTestPool(subMgr)
+
+	sub := subscription.NewSubscription("sub-a", "sub-a", "https://example.com/a", true, false)
+	subMgr.Register(sub)
+
+	hash := addRoutableNodeForSubscription(
+		t,
+		pool,
+		sub,
+		[]byte(`{"type":"ss","server":"1.1.1.1","port":443}`),
+		"203.0.113.31",
+	)
+
+	entry, ok := pool.GetEntry(hash)
+	if !ok {
+		t.Fatalf("node %s missing", hash.Hex())
+	}
+	now := time.Date(2026, 6, 5, 1, 2, 3, 4, time.UTC)
+	entry.LatencyTable.LoadEntry("github.com", node.DomainLatencyStats{
+		Ewma:        60 * time.Millisecond,
+		LastUpdated: now,
+	})
+	entry.LatencyTable.LoadEntry("cloudflare.com", node.DomainLatencyStats{
+		Ewma:        40 * time.Millisecond,
+		LastUpdated: now.Add(time.Second),
+	})
+
+	cp := &ControlPlaneService{
+		Pool:   pool,
+		SubMgr: subMgr,
+		GeoIP:  &geoip.Service{},
+	}
+
+	got, err := cp.GetNode(hash.Hex())
+	if err != nil {
+		t.Fatalf("GetNode: %v", err)
+	}
+	if len(got.Latencies) != 3 {
+		t.Fatalf("latencies len = %d, want 3", len(got.Latencies))
+	}
+	if got.Latencies[0].Domain != "cloudflare.com" || got.Latencies[0].LatencyEWMAMs != 40 {
+		t.Fatalf("first latency = %+v, want cloudflare.com/40", got.Latencies[0])
+	}
+	if got.Latencies[1].Domain != "example.com" || got.Latencies[1].LatencyEWMAMs != 25 {
+		t.Fatalf("second latency = %+v, want example.com/25", got.Latencies[1])
+	}
+	if got.Latencies[2].Domain != "github.com" || got.Latencies[2].LatencyEWMAMs != 60 {
+		t.Fatalf("third latency = %+v, want github.com/60", got.Latencies[2])
+	}
+	if got.Latencies[0].LastUpdated == "" || got.Latencies[1].LastUpdated == "" || got.Latencies[2].LastUpdated == "" {
+		t.Fatalf("last_updated should be present: %+v", got.Latencies)
+	}
+}
+
 func TestListNodes_ProbedSinceUsesLastLatencyProbeAttempt(t *testing.T) {
 	subMgr := topology.NewSubscriptionManager()
 	pool := newNodeListTestPool(subMgr)

--- a/internal/service/control_plane_platform.go
+++ b/internal/service/control_plane_platform.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -589,22 +590,23 @@ type PlatformSpecFilter struct {
 
 // NodeSummary is the API response for a node.
 type NodeSummary struct {
-	NodeHash                         string    `json:"node_hash"`
-	CreatedAt                        string    `json:"created_at"`
-	Enabled                          bool      `json:"enabled"`
-	DisplayTag                       string    `json:"display_tag,omitempty"`
-	HasOutbound                      bool      `json:"has_outbound"`
-	LastError                        string    `json:"last_error,omitempty"`
-	CircuitOpenSince                 *string   `json:"circuit_open_since"`
-	FailureCount                     int       `json:"failure_count"`
-	EgressIP                         string    `json:"egress_ip,omitempty"`
-	Region                           string    `json:"region,omitempty"`
-	LastEgressUpdate                 string    `json:"last_egress_update,omitempty"`
-	LastLatencyProbeAttempt          string    `json:"last_latency_probe_attempt,omitempty"`
-	LastAuthorityLatencyProbeAttempt string    `json:"last_authority_latency_probe_attempt,omitempty"`
-	ReferenceLatencyMs               *float64  `json:"reference_latency_ms,omitempty"`
-	LastEgressUpdateAttempt          string    `json:"last_egress_update_attempt,omitempty"`
-	Tags                             []NodeTag `json:"tags"`
+	NodeHash                         string               `json:"node_hash"`
+	CreatedAt                        string               `json:"created_at"`
+	Enabled                          bool                 `json:"enabled"`
+	DisplayTag                       string               `json:"display_tag,omitempty"`
+	HasOutbound                      bool                 `json:"has_outbound"`
+	LastError                        string               `json:"last_error,omitempty"`
+	CircuitOpenSince                 *string              `json:"circuit_open_since"`
+	FailureCount                     int                  `json:"failure_count"`
+	EgressIP                         string               `json:"egress_ip,omitempty"`
+	Region                           string               `json:"region,omitempty"`
+	LastEgressUpdate                 string               `json:"last_egress_update,omitempty"`
+	LastLatencyProbeAttempt          string               `json:"last_latency_probe_attempt,omitempty"`
+	LastAuthorityLatencyProbeAttempt string               `json:"last_authority_latency_probe_attempt,omitempty"`
+	ReferenceLatencyMs               *float64             `json:"reference_latency_ms,omitempty"`
+	Latencies                        []NodeLatencySummary `json:"latencies,omitempty"`
+	LastEgressUpdateAttempt          string               `json:"last_egress_update_attempt,omitempty"`
+	Tags                             []NodeTag            `json:"tags"`
 }
 
 // IsHealthyAndEnabled follows the node-summary health rule used by API/UI
@@ -618,6 +620,12 @@ type NodeTag struct {
 	SubscriptionName        string `json:"subscription_name"`
 	Tag                     string `json:"tag"`
 	SubscriptionCreatedAtNs int64  `json:"-"`
+}
+
+type NodeLatencySummary struct {
+	Domain        string  `json:"domain"`
+	LatencyEWMAMs float64 `json:"latency_ewma_ms"`
+	LastUpdated   string  `json:"last_updated"`
 }
 
 func (s *ControlPlaneService) nodeEntryToSummary(h node.Hash, entry *node.NodeEntry) NodeSummary {
@@ -664,6 +672,19 @@ func (s *ControlPlaneService) nodeEntryToSummary(h node.Hash, entry *node.NodeEn
 				ns.ReferenceLatencyMs = &avgMs
 			}
 		}
+	}
+	if entry.LatencyTable != nil {
+		entry.LatencyTable.Range(func(domain string, stats node.DomainLatencyStats) bool {
+			ns.Latencies = append(ns.Latencies, NodeLatencySummary{
+				Domain:        domain,
+				LatencyEWMAMs: float64(stats.Ewma.Milliseconds()),
+				LastUpdated:   stats.LastUpdated.UTC().Format(time.RFC3339Nano),
+			})
+			return true
+		})
+		sort.Slice(ns.Latencies, func(i, j int) bool {
+			return ns.Latencies[i].Domain < ns.Latencies[j].Domain
+		})
 	}
 	if lastEgressAttempt := entry.LastEgressUpdateAttempt.Load(); lastEgressAttempt > 0 {
 		ns.LastEgressUpdateAttempt = time.Unix(0, lastEgressAttempt).UTC().Format(time.RFC3339Nano)

--- a/webui/src/features/nodes/api.ts
+++ b/webui/src/features/nodes/api.ts
@@ -22,6 +22,7 @@ type ApiNodeSummary = Omit<NodeSummary, "tags"> & {
   last_latency_probe_attempt?: string | null;
   last_authority_latency_probe_attempt?: string | null;
   last_egress_update_attempt?: string | null;
+  latencies?: NodeSummary["latencies"] | null;
 };
 
 function normalizeNode(raw: ApiNodeSummary): NodeSummary {
@@ -39,6 +40,7 @@ function normalizeNode(raw: ApiNodeSummary): NodeSummary {
     last_latency_probe_attempt: raw.last_latency_probe_attempt || "",
     last_authority_latency_probe_attempt: raw.last_authority_latency_probe_attempt || "",
     last_egress_update_attempt: raw.last_egress_update_attempt || "",
+    latencies: Array.isArray(raw.latencies) ? raw.latencies : [],
   };
 
   // Backend uses `omitempty`; field missing means "no reference latency".

--- a/webui/src/features/nodes/types.ts
+++ b/webui/src/features/nodes/types.ts
@@ -20,7 +20,14 @@ export type NodeSummary = {
   last_latency_probe_attempt?: string;
   last_authority_latency_probe_attempt?: string;
   last_egress_update_attempt?: string;
+  latencies?: NodeLatencySummary[];
   tags: NodeTag[];
+};
+
+export type NodeLatencySummary = {
+  domain: string;
+  latency_ewma_ms: number;
+  last_updated: string;
 };
 
 export type PageResponse<T> = {


### PR DESCRIPTION
## What

- NodeSummary now includes an optional latencies array (domain, EWMA latency ms, last updated) populated from each node's latency table.
- webui nodes feature: type definitions + API response normalization for the new field.
- Service-level tests for the summary shape.

## Why

Makes per-node, per-probe-domain latency visible in the nodes API/UI instead of only the single reference latency — useful when a node serves different upstream domains with very different latencies.