### PR TITLE
feat(proxy): per-request node route override (Node.<hash> credential / X-Resin-Node-Hash header)

### DIFF
--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -45,6 +45,12 @@ type ForwardProxy struct {
 	bypass            *TargetBypassMatcher
 }
 
+type forwardAuthResult struct {
+	PlatformName string
+	Account      string
+	Override     routeOverride
+}
+
 // NewForwardProxy creates a new forward proxy handler.
 func NewForwardProxy(cfg ForwardProxyConfig) *ForwardProxy {
 	ev := cfg.Events
@@ -99,31 +105,52 @@ func (p *ForwardProxy) authenticate(r *http.Request) (string, string, *ProxyErro
 }
 
 func (p *ForwardProxy) authenticateV1(r *http.Request) (string, string, *ProxyError) {
+	result, err := p.authenticateRouteV1(r)
+	if err != nil {
+		return "", "", err
+	}
+	return result.PlatformName, result.Account, nil
+}
+
+func (p *ForwardProxy) authenticateRouteV1(r *http.Request) (forwardAuthResult, *ProxyError) {
 	auth := r.Header.Get("Proxy-Authorization")
 	if p.token == "" {
 		credential, ok := parseProxyAuthorizationCredentialV1(auth)
 		if !ok {
 			if requireProxyAuthInfo(r) {
-				return "", "", ErrAuthRequired
+				return forwardAuthResult{}, ErrAuthRequired
 			}
-			return "", "", nil
+			return forwardAuthResult{Override: routeOverrideFromHeader(r)}, nil
 		}
 		if requireProxyAuthInfo(r) && !hasBasicUserInfo(credential) {
-			return "", "", ErrAuthRequired
+			return forwardAuthResult{}, ErrAuthRequired
 		}
-		platName, account := parseForwardCredentialV1WhenAuthDisabled(credential)
-		return platName, account, nil
-	}
+		override, _, platName, account := parseForwardCredentialV1RouteOverride(credential)
+		if override.NodeHash == "" {
+			platName, account = parseForwardCredentialV1WhenAuthDisabled(credential)
+			override = routeOverrideFromHeader(r)
+		}
+		return forwardAuthResult{PlatformName: platName, Account: account, Override: override}, nil	}
 
 	credential, ok := parseProxyAuthorizationCredentialV1(auth)
 	if !ok {
-		return "", "", ErrAuthRequired
+		return forwardAuthResult{}, ErrAuthRequired
 	}
-	token, platName, account := parseForwardCredentialV1(credential)
+	override, token, platName, account := parseForwardCredentialV1RouteOverride(credential)
 	if token != p.token {
-		return "", "", ErrAuthFailed
+		return forwardAuthResult{}, ErrAuthFailed
 	}
-	return platName, account, nil
+	if override.NodeHash == "" {
+		override = routeOverrideFromHeader(r)
+	}
+	return forwardAuthResult{PlatformName: platName, Account: account, Override: override}, nil
+}
+
+func routeOverrideFromHeader(r *http.Request) routeOverride {
+	if r == nil {
+		return routeOverride{}
+	}
+	return routeOverride{NodeHash: strings.TrimSpace(r.Header.Get("X-Resin-Node-Hash"))}
 }
 
 func requireProxyAuthInfo(r *http.Request) bool {
@@ -211,11 +238,12 @@ func prepareForwardOutboundRequest(in *http.Request) *http.Request {
 	// Do not propagate client-side close semantics to upstream transport reuse.
 	req.Close = false
 	stripHopByHopHeaders(req.Header)
+	req.Header.Del("X-Resin-Node-Hash")
 	return req
 }
 
 func (p *ForwardProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
-	platName, account, authErr := p.authenticate(r)
+	auth, authErr := p.authenticateRouteV1(r)
 	if authErr != nil {
 		writeProxyError(w, authErr)
 		return
@@ -224,7 +252,7 @@ func (p *ForwardProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	lifecycle := newRequestLifecycle(p.events, r, ProxyTypeForward, false)
 	lifecycle.setTarget(r.Host, r.URL.String())
 	defer lifecycle.finish()
-	lifecycle.setAccount(account)
+	lifecycle.setAccount(auth.Account)
 
 	var route routing.RouteResult
 	var hasRoute bool
@@ -232,7 +260,7 @@ func (p *ForwardProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	if p.bypass != nil && p.bypass.ShouldBypass(r.Host) {
 		transport = p.directHTTPTransport()
 	} else {
-		routed, routeErr := resolveRoutedOutbound(p.router, p.pool, platName, account, r.Host)
+		routed, routeErr := resolveRoutedOutbound(p.router, p.pool, auth.PlatformName, auth.Account, r.Host, auth.Override)
 		if routeErr != nil {
 			lifecycle.setProxyError(routeErr)
 			lifecycle.setHTTPStatus(routeErr.HTTPCode)
@@ -313,7 +341,7 @@ func (p *ForwardProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (p *ForwardProxy) handleCONNECT(w http.ResponseWriter, r *http.Request) {
 	target := r.Host
-	platName, account, authErr := p.authenticate(r)
+	auth, authErr := p.authenticateRouteV1(r)
 	if authErr != nil {
 		writeProxyError(w, authErr)
 		return
@@ -322,7 +350,7 @@ func (p *ForwardProxy) handleCONNECT(w http.ResponseWriter, r *http.Request) {
 	lifecycle := newRequestLifecycle(p.events, r, ProxyTypeForward, true)
 	lifecycle.setTarget(target, "")
 	defer lifecycle.finish()
-	lifecycle.setAccount(account)
+	lifecycle.setAccount(auth.Account)
 
 	prepare := prepareConnectTunnel(
 		r.Context(),
@@ -333,11 +361,12 @@ func (p *ForwardProxy) handleCONNECT(w http.ResponseWriter, r *http.Request) {
 			metricsSink: p.metricsSink,
 			bypass:      p.bypass,
 		},
-		platName,
-		account,
+		auth.PlatformName,
+		auth.Account,
 		target,
+		auth.Override,
 	)
-	if prepare.route.PlatformID != "" {
+	if !prepare.route.NodeHash.IsZero() {
 		lifecycle.setRouteResult(prepare.route)
 	}
 	if prepare.session == nil {

--- a/internal/proxy/identity_test.go
+++ b/internal/proxy/identity_test.go
@@ -75,6 +75,27 @@ func TestParseForwardCredentialV1(t *testing.T) {
 	}
 }
 
+func TestParseForwardCredentialV1RouteOverride(t *testing.T) {
+	override, token, plat, account := parseForwardCredentialV1RouteOverride("Node.00112233445566778899aabbccddeeff:tok")
+	if token != "tok" || plat != "" || account != "" {
+		t.Fatalf("got token=%q plat=%q account=%q, want token=%q empty identity", token, plat, account, "tok")
+	}
+	if override.NodeHash != "00112233445566778899aabbccddeeff" {
+		t.Fatalf("node hash override: got %q", override.NodeHash)
+	}
+}
+
+func TestParseForwardCredentialV1RouteOverrideNonNodeCredential(t *testing.T) {
+	override, token, plat, account := parseForwardCredentialV1RouteOverride("Default.user-a:tok")
+	if override.NodeHash != "" {
+		t.Fatalf("unexpected node hash override: %q", override.NodeHash)
+	}
+	if token != "tok" || plat != "Default" || account != "user-a" {
+		t.Fatalf("got token=%q plat=%q account=%q, want tok Default user-a", token, plat, account)
+	}
+}
+
+
 func TestParseForwardCredentialV1WhenAuthDisabled(t *testing.T) {
 	tests := []struct {
 		credential string

--- a/internal/proxy/identity_v1.go
+++ b/internal/proxy/identity_v1.go
@@ -2,6 +2,8 @@ package proxy
 
 import "strings"
 
+const v1NodeOverridePlatform = "Node"
+
 // parseV1PlatformAccountIdentity parses V1 identity segment:
 // "Platform.Account" (preferred) or "Platform:Account".
 func parseV1PlatformAccountIdentity(identity string) (string, string) {
@@ -32,6 +34,15 @@ func parseForwardCredentialV1(credential string) (token string, platform string,
 	}
 	platform, account = parseV1PlatformAccountIdentity(identity)
 	return token, platform, account
+}
+
+func parseForwardCredentialV1RouteOverride(credential string) (override routeOverride, token string, platform string, account string) {
+	token, platform, account = parseForwardCredentialV1(credential)
+	if strings.EqualFold(platform, v1NodeOverridePlatform) && strings.TrimSpace(account) != "" {
+		override.NodeHash = strings.TrimSpace(account)
+		return override, token, "", ""
+	}
+	return override, token, platform, account
 }
 
 // parseForwardCredentialV1WhenAuthDisabled parses optional identity when

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -378,6 +378,56 @@ func TestForwardProxy_Authentication_V1(t *testing.T) {
 func TestForwardProxy_Authentication_V1RejectsTokenFirstCredentialShape(t *testing.T) {
 	fp := &ForwardProxy{token: "tok", events: NoOpEventEmitter{}}
 	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	req.Header.Set("Proxy-Authorization", basicAuth("Node.00112233445566778899aabbccddeeff:tok", ""))
+
+	_, _, err := fp.authenticate(req)
+	if err != ErrAuthFailed {
+		t.Fatalf("expected ErrAuthFailed, got %v", err)
+	}
+}
+
+func TestForwardProxy_Authentication_V1NodeOverrideCredential(t *testing.T) {
+	rawCredential := func(raw string) string {
+		return "Basic " + base64.StdEncoding.EncodeToString([]byte(raw))
+	}
+
+	fp := &ForwardProxy{token: "tok", events: NoOpEventEmitter{}}
+	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	req.Header.Set("Proxy-Authorization", rawCredential("Node.00112233445566778899aabbccddeeff:tok"))
+
+	auth, err := fp.authenticateRouteV1(req)
+	if err != nil {
+		t.Fatalf("unexpected auth error: %v", err)
+	}
+	if auth.PlatformName != "" || auth.Account != "" {
+		t.Fatalf("route override should not set identity: %+v", auth)
+	}
+	if auth.Override.NodeHash != "00112233445566778899aabbccddeeff" {
+		t.Fatalf("node override: got %q", auth.Override.NodeHash)
+	}
+}
+
+func TestForwardProxy_Authentication_HeaderNodeOverride(t *testing.T) {
+	fp := &ForwardProxy{token: "tok", events: NoOpEventEmitter{}}
+	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	req.Header.Set("Proxy-Authorization", basicAuth("plat.acct", "tok"))
+	req.Header.Set("X-Resin-Node-Hash", "00112233445566778899aabbccddeeff")
+
+	auth, err := fp.authenticateRouteV1(req)
+	if err != nil {
+		t.Fatalf("unexpected auth error: %v", err)
+	}
+	if auth.PlatformName != "plat" || auth.Account != "acct" {
+		t.Fatalf("identity: got plat=%q acct=%q", auth.PlatformName, auth.Account)
+	}
+	if auth.Override.NodeHash != "00112233445566778899aabbccddeeff" {
+		t.Fatalf("node override: got %q", auth.Override.NodeHash)
+	}
+}
+
+func TestForwardProxy_Authentication_V1RejectsLegacyCredentialShape(t *testing.T) {
+	fp := &ForwardProxy{token: "tok", events: NoOpEventEmitter{}}
+	req := httptest.NewRequest("GET", "http://example.com/", nil)
 	req.Header.Set("Proxy-Authorization", basicAuth("tok", "plat:acct"))
 
 	_, _, err := fp.authenticate(req)

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -303,7 +303,7 @@ func (p *ReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if p.bypass != nil && p.bypass.ShouldBypass(parsed.Host) {
 		transport = p.directHTTPTransport()
 	} else {
-		routed, routeErr := resolveRoutedOutbound(p.router, p.pool, parsed.PlatformName, account, parsed.Host)
+		routed, routeErr := resolveRoutedOutbound(p.router, p.pool, parsed.PlatformName, account, parsed.Host, routeOverride{})
 		if routeErr != nil {
 			lifecycle.setProxyError(routeErr)
 			lifecycle.setHTTPStatus(routeErr.HTTPCode)

--- a/internal/proxy/route_outbound.go
+++ b/internal/proxy/route_outbound.go
@@ -1,10 +1,21 @@
 package proxy
 
 import (
+	"strings"
+
+	"github.com/Resinat/Resin/internal/node"
 	"github.com/Resinat/Resin/internal/outbound"
 	"github.com/Resinat/Resin/internal/routing"
 	"github.com/sagernet/sing-box/adapter"
 )
+
+type routeOverride struct {
+	NodeHash string
+}
+
+type healthyEnabledEvaluator interface {
+	MakeHealthyAndEnabledEvaluator() func(*node.NodeEntry) bool
+}
 
 type routedOutbound struct {
 	Route    routing.RouteResult
@@ -17,7 +28,12 @@ func resolveRoutedOutbound(
 	platformName string,
 	account string,
 	target string,
+	override routeOverride,
 ) (routedOutbound, *ProxyError) {
+	if strings.TrimSpace(override.NodeHash) != "" {
+		return resolveNodeHashOverrideOutbound(pool, override.NodeHash)
+	}
+
 	result, err := router.RouteRequest(platformName, account, target)
 	if err != nil {
 		return routedOutbound{}, mapRouteError(err)
@@ -36,4 +52,38 @@ func resolveRoutedOutbound(
 		Route:    result,
 		Outbound: *obPtr,
 	}, nil
+}
+
+func resolveNodeHashOverrideOutbound(pool outbound.PoolAccessor, nodeHash string) (routedOutbound, *ProxyError) {
+	h, err := node.ParseHex(strings.TrimSpace(nodeHash))
+	if err != nil {
+		return routedOutbound{}, ErrNoAvailableNodes
+	}
+
+	entry, ok := pool.GetEntry(h)
+	if !ok || !routeOverrideEntryAvailable(pool, entry) {
+		return routedOutbound{}, ErrNoAvailableNodes
+	}
+	obPtr := entry.Outbound.Load()
+	if obPtr == nil {
+		return routedOutbound{}, ErrNoAvailableNodes
+	}
+
+	return routedOutbound{
+		Route: routing.RouteResult{
+			NodeHash: h,
+			EgressIP: entry.GetEgressIP(),
+		},
+		Outbound: *obPtr,
+	}, nil
+}
+
+func routeOverrideEntryAvailable(pool outbound.PoolAccessor, entry *node.NodeEntry) bool {
+	if entry == nil {
+		return false
+	}
+	if evaluatorPool, ok := pool.(healthyEnabledEvaluator); ok {
+		return evaluatorPool.MakeHealthyAndEnabledEvaluator()(entry)
+	}
+	return entry.IsHealthy()
 }

--- a/internal/proxy/route_outbound_test.go
+++ b/internal/proxy/route_outbound_test.go
@@ -1,0 +1,83 @@
+package proxy
+
+import (
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/Resinat/Resin/internal/node"
+	"github.com/Resinat/Resin/internal/platform"
+	"github.com/Resinat/Resin/internal/routing"
+	"github.com/sagernet/sing-box/adapter"
+)
+
+type routeOverrideTestPool struct {
+	entries map[node.Hash]*node.NodeEntry
+}
+
+func (p *routeOverrideTestPool) GetEntry(hash node.Hash) (*node.NodeEntry, bool) {
+	entry, ok := p.entries[hash]
+	return entry, ok
+}
+
+func (p *routeOverrideTestPool) GetPlatform(id string) (*platform.Platform, bool) {
+	return nil, false
+}
+
+func (p *routeOverrideTestPool) GetPlatformByName(name string) (*platform.Platform, bool) {
+	return nil, false
+}
+
+func (p *routeOverrideTestPool) RangePlatforms(fn func(*platform.Platform) bool) {}
+
+func (p *routeOverrideTestPool) RangeNodes(fn func(node.Hash, *node.NodeEntry) bool) {
+	for h, entry := range p.entries {
+		if !fn(h, entry) {
+			return
+		}
+	}
+}
+
+func newRouteOverrideEntry(hash node.Hash) *node.NodeEntry {
+	entry := node.NewNodeEntry(hash, nil, time.Now(), 0)
+	ob := &mockOutbound{}
+	var wrapped adapter.Outbound = ob
+	entry.Outbound.Store(&wrapped)
+	entry.SetEgressIP(netip.MustParseAddr("203.0.113.20"))
+	return entry
+}
+
+func TestResolveRoutedOutbound_NodeHashOverrideBypassesRouter(t *testing.T) {
+	hash := node.Hash{1, 2, 3}
+	pool := &routeOverrideTestPool{
+		entries: map[node.Hash]*node.NodeEntry{
+			hash: newRouteOverrideEntry(hash),
+		},
+	}
+
+	routed, routeErr := resolveRoutedOutbound(nil, pool, "missing-platform", "acct", "example.com", routeOverride{NodeHash: hash.Hex()})
+	if routeErr != nil {
+		t.Fatalf("unexpected route error: %v", routeErr)
+	}
+	if routed.Route.NodeHash != hash {
+		t.Fatalf("node hash: got %s, want %s", routed.Route.NodeHash.Hex(), hash.Hex())
+	}
+	if routed.Route.PlatformName != "" || routed.Route.LeaseCreated {
+		t.Fatalf("override should not create platform lease context: %+v", routed.Route)
+	}
+}
+
+func TestResolveRoutedOutbound_NodeHashOverrideRejectsUnavailableNode(t *testing.T) {
+	hash := node.Hash{4, 5, 6}
+	pool := &routeOverrideTestPool{
+		entries: map[node.Hash]*node.NodeEntry{
+			hash: node.NewNodeEntry(hash, nil, time.Now(), 0),
+		},
+	}
+	router := routing.NewRouter(routing.RouterConfig{Pool: pool})
+
+	_, routeErr := resolveRoutedOutbound(router, pool, "", "", "example.com", routeOverride{NodeHash: hash.Hex()})
+	if routeErr != ErrNoAvailableNodes {
+		t.Fatalf("route error: got %v, want %v", routeErr, ErrNoAvailableNodes)
+	}
+}

--- a/internal/proxy/socks5.go
+++ b/internal/proxy/socks5.go
@@ -123,8 +123,9 @@ func (s *Socks5Inbound) ServeConnContext(baseCtx context.Context, conn net.Conn)
 		handshake.platformName,
 		handshake.account,
 		handshake.target,
+		routeOverride{},
 	)
-	if prepare.route.PlatformID != "" {
+	if !prepare.route.NodeHash.IsZero() {
 		lifecycle.setRouteResult(prepare.route)
 	}
 	if prepare.session == nil {

--- a/internal/proxy/tunnel.go
+++ b/internal/proxy/tunnel.go
@@ -71,12 +71,13 @@ func prepareConnectTunnel(
 	platformName string,
 	account string,
 	target string,
+	override routeOverride,
 ) tunnelPrepareResult {
 	if deps.bypass != nil && deps.bypass.ShouldBypass(target) {
 		return prepareDirectConnectTunnel(ctx, deps, target)
 	}
 
-	routed, routeErr := resolveRoutedOutbound(deps.router, deps.pool, platformName, account, target)
+	routed, routeErr := resolveRoutedOutbound(deps.router, deps.pool, platformName, account, target, override)
 	if routeErr != nil {
 		return tunnelPrepareResult{proxyErr: routeErr}
 	}


### PR DESCRIPTION
## What

Adds the ability to pin a proxy request to a specific node:

- V1 credential form Node.<node-hash>:<token> selects the node directly.
- Alternatively, an X-Resin-Node-Hash request header overrides routing.
- The override is honored in HTTP forward, CONNECT tunnel, and SOCKS5 paths; falls back to normal platform/account routing when absent.

Also includes esolveRoutedOutbound override plumbing and tests for credential parsing, header override, and rejection cases.

## Why

Operators sometimes need to pin a single request/session to one known-good node (e.g., debugging a platform account against a specific exit) without changing platform allocation policy.