### PR TITLE
chore(webui): default nodes page size to 20

### DIFF
--- a/webui/src/features/nodes/NodesPage.tsx
+++ b/webui/src/features/nodes/NodesPage.tsx
@@ -270,7 +270,7 @@ export function NodesPage() {
   const [sortBy, setSortBy] = useState<NodeSortBy>("tag");
   const [sortOrder, setSortOrder] = useState<SortOrder>("asc");
   const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState<number>(200);
+  const [pageSize, setPageSize] = useState<number>(20);
   const [selectedNodeHash, setSelectedNodeHash] = useState("");
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [pendingEgressHashes, setPendingEgressHashes] = useState<Set<string>>(() => new Set());


### PR DESCRIPTION
## What

Lowers the default nodes page page size from 200 to 20.

## Why

With large node pools (tens of thousands of nodes), rendering 200 rows per page makes the table sluggish; 20 keeps the UI responsive. The page size remains user-adjustable.